### PR TITLE
23-Add-tests-for-each-cleaner-working-on-local-methods-that-trait-methods-are-not-duplicated-in-class

### DIFF
--- a/src/Chanel-Tests/ChanelAbstractCleanerTest.class.st
+++ b/src/Chanel-Tests/ChanelAbstractCleanerTest.class.st
@@ -52,6 +52,21 @@ ChanelAbstractCleanerTest >> createClassNamed: aSymbol [
 ]
 
 { #category : #helpers }
+ChanelAbstractCleanerTest >> createDefaultClass [
+	^ self createClassNamed: self defaultClassName
+]
+
+{ #category : #helpers }
+ChanelAbstractCleanerTest >> createDefaultTestClass [
+	^ self createTestCaseNamed: self defaultClassName
+]
+
+{ #category : #helpers }
+ChanelAbstractCleanerTest >> createDefaultTrait [
+	^ self createTraitNamed: self defaultTraitName
+]
+
+{ #category : #helpers }
 ChanelAbstractCleanerTest >> createSubclassOf: aClass named: aSymbol [
 	^ aClass
 		subclass: aSymbol
@@ -68,6 +83,16 @@ ChanelAbstractCleanerTest >> createTestCaseNamed: aSymbol [
 { #category : #helpers }
 ChanelAbstractCleanerTest >> createTraitNamed: aSymbol [
 	^ Trait named: aSymbol uses: {} package: package name
+]
+
+{ #category : #accessing }
+ChanelAbstractCleanerTest >> defaultClassName [
+	^ (self class name , 'Fake') asSymbol
+]
+
+{ #category : #accessing }
+ChanelAbstractCleanerTest >> defaultTraitName [
+	^ ('T' , self defaultClassName) asSymbol
 ]
 
 { #category : #running }

--- a/src/Chanel-Tests/ChanelConditionalSimplifierCleanerTest.class.st
+++ b/src/Chanel-Tests/ChanelConditionalSimplifierCleanerTest.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #running }
 ChanelConditionalSimplifierCleanerTest >> setUp [
 	super setUp.
-	class := self createTestCaseNamed: #ChanelConditionalSimplifierMock
+	class := self createDefaultTestClass
 ]
 
 { #category : #tests }
@@ -70,6 +70,30 @@ ChanelConditionalSimplifierCleanerTest >> testReplacementDoesNotRemoveExtensions
   {2}' format: {self selector . '10 ifNotNil: [ false ]'}).
 
 	self assert: (class >> self selector) protocol equals: self extensionProtocol
+]
+
+{ #category : #tests }
+ChanelConditionalSimplifierCleanerTest >> testReplacementInTraits [
+	| trait |
+	trait := self createDefaultTrait.
+
+	class setTraitComposition: trait.
+
+	trait
+		compile:
+			('{1}
+  {2}' format: {self selector . '10 isNil ifFalse: [ false ]'}).
+
+	self runCleaner.
+
+	self
+		assert: (trait >> self selector) sourceCode
+		equals:
+			('{1}
+  {2}' format: {self selector . '10 ifNotNil: [ false ]'}).
+
+	self assert: (trait localSelectors includes: self selector).
+	self deny: (class localSelectors includes: self selector)
 ]
 
 { #category : #tests }

--- a/src/Chanel-Tests/ChanelDuplicatedMethodFromTraitCleanerTest.class.st
+++ b/src/Chanel-Tests/ChanelDuplicatedMethodFromTraitCleanerTest.class.st
@@ -4,16 +4,22 @@ A ChanelDuplicatedMethodFromTraitCleanerTest is a test class for testing the beh
 Class {
 	#name : #ChanelDuplicatedMethodFromTraitCleanerTest,
 	#superclass : #ChanelAbstractCleanerTest,
+	#instVars : [
+		'trait'
+	],
 	#category : #'Chanel-Tests'
 }
 
+{ #category : #running }
+ChanelDuplicatedMethodFromTraitCleanerTest >> setUp [
+	super setUp.
+	class := self createDefaultClass.
+	trait := self createDefaultTrait
+]
+
 { #category : #tests }
 ChanelDuplicatedMethodFromTraitCleanerTest >> testDoesNotRemoveDuplicatedMethodFromTraitIfASTDifferent [
-	| trait |
-	class := self createClassNamed: #ChanelDuplicatedMethodFromTraitFake.
-	trait := self createTraitNamed: #TChanelDuplicatedMethodFromTraitFake.
-
-	class addToComposition: trait.
+	class setTraitComposition: trait.
 
 	trait
 		compile:
@@ -33,19 +39,17 @@ ChanelDuplicatedMethodFromTraitCleanerTest >> testDoesNotRemoveDuplicatedMethodF
 
 { #category : #tests }
 ChanelDuplicatedMethodFromTraitCleanerTest >> testDoesNotRemoveDuplicatedMethodFromTraitIfEquivalentIsInSuperclasse [
-	| trait superclass |
-	superclass := self createClassNamed: #ChanelSupDuplicatedMethodFromTraitFake.
-	class := self createSubclassOf: superclass named: #ChanelDuplicatedMethodFromTraitFake.
-	trait := self createTraitNamed: #TChanelDuplicatedMethodFromTraitFake.
+	| subClass |
+	subClass := self createSubclassOf: class named: #ChanelDuplicatedMethodFromTraitFake.
 
-	class addToComposition: trait.
+	subClass setTraitComposition: trait.
 
 	trait
 		compile:
 			'one
 	^ #one'.
 
-	superclass
+	class
 		compile:
 			'one
 			<pragma>
@@ -54,17 +58,13 @@ ChanelDuplicatedMethodFromTraitCleanerTest >> testDoesNotRemoveDuplicatedMethodF
 	self runCleaner.
 
 	self assert: (trait localSelectors includes: #one).
-	self assert: (superclass localSelectors includes: #one).
-	self deny: (class localSelectors includes: #one)
+	self assert: (class localSelectors includes: #one).
+	self deny: (subClass localSelectors includes: #one)
 ]
 
 { #category : #tests }
 ChanelDuplicatedMethodFromTraitCleanerTest >> testDoesNotRemoveDuplicatedMethodFromTraitIfPragmaIsPresent [
-	| trait |
-	class := self createClassNamed: #ChanelDuplicatedMethodFromTraitFake.
-	trait := self createTraitNamed: #TChanelDuplicatedMethodFromTraitFake.
-
-	class addToComposition: trait.
+	class setTraitComposition: trait.
 
 	trait
 		compile:
@@ -85,10 +85,6 @@ ChanelDuplicatedMethodFromTraitCleanerTest >> testDoesNotRemoveDuplicatedMethodF
 
 { #category : #tests }
 ChanelDuplicatedMethodFromTraitCleanerTest >> testDoesNothingToClassWithoutTraitComposition [
-	| trait |
-	class := self createClassNamed: #ChanelDuplicatedMethodFromTraitFake.
-	trait := self createTraitNamed: #TChanelDuplicatedMethodFromTraitFake.
-
 	trait
 		compile:
 			'one
@@ -107,11 +103,7 @@ ChanelDuplicatedMethodFromTraitCleanerTest >> testDoesNothingToClassWithoutTrait
 
 { #category : #tests }
 ChanelDuplicatedMethodFromTraitCleanerTest >> testRemoveDuplicatedMethodFromTrait [
-	| trait |
-	class := self createClassNamed: #ChanelDuplicatedMethodFromTraitFake.
-	trait := self createTraitNamed: #TChanelDuplicatedMethodFromTraitFake.
-
-	class addToComposition: trait.
+	class setTraitComposition: trait.
 
 	trait
 		compile:
@@ -131,11 +123,7 @@ ChanelDuplicatedMethodFromTraitCleanerTest >> testRemoveDuplicatedMethodFromTrai
 
 { #category : #tests }
 ChanelDuplicatedMethodFromTraitCleanerTest >> testRemoveDuplicatedMethodFromTraitIfFormattingDifferent [
-	| trait |
-	class := self createClassNamed: #ChanelDuplicatedMethodFromTraitFake.
-	trait := self createTraitNamed: #TChanelDuplicatedMethodFromTraitFake.
-
-	class addToComposition: trait.
+	class setTraitComposition: trait.
 
 	trait
 		compile:
@@ -156,11 +144,7 @@ ChanelDuplicatedMethodFromTraitCleanerTest >> testRemoveDuplicatedMethodFromTrai
 
 { #category : #tests }
 ChanelDuplicatedMethodFromTraitCleanerTest >> testRemoveDuplicatedMethodFromTraitOnClassSide [
-	| trait |
-	class := self createClassNamed: #ChanelDuplicatedMethodFromTraitFake.
-	trait := self createTraitNamed: #TChanelDuplicatedMethodFromTraitFake.
-
-	class addToComposition: trait.
+	class setTraitComposition: trait.
 
 	trait class
 		compile:

--- a/src/Chanel-Tests/ChanelEnsureSuperIsCalledCleanerTest.class.st
+++ b/src/Chanel-Tests/ChanelEnsureSuperIsCalledCleanerTest.class.st
@@ -10,10 +10,14 @@ Class {
 	#category : #'Chanel-Tests'
 }
 
+{ #category : #running }
+ChanelEnsureSuperIsCalledCleanerTest >> setUp [
+	super setUp.
+	class := self createDefaultTestClass
+]
+
 { #category : #'tests - initialize' }
 ChanelEnsureSuperIsCalledCleanerTest >> testAddSuperInitialize [
-	class := self createClassNamed: #ChanelTestClass.
-
 	class compile: 'initialize
   self assert: true'.
 
@@ -31,10 +35,35 @@ ChanelEnsureSuperIsCalledCleanerTest >> testAddSuperInitialize [
 	self deny: oldMethod identicalTo: class >> #initialize
 ]
 
+{ #category : #'tests - initialize' }
+ChanelEnsureSuperIsCalledCleanerTest >> testAddSuperInitializeInTrait [
+	| trait |
+	trait := self createDefaultTrait.
+
+	class setTraitComposition: trait.
+
+	trait
+		compile:
+			'initialize
+  self assert: true'.
+
+	oldMethod := trait >> #initialize.
+
+	self runCleaner.
+
+	self
+		assert: (trait >> #initialize) sourceCode
+		equals:
+			'initialize
+  super initialize.
+  self assert: true'.
+
+	self assert: (trait localSelectors includes: #initialize).
+	self deny: (class localSelectors includes: #initialize)
+]
+
 { #category : #'tests - setup' }
 ChanelEnsureSuperIsCalledCleanerTest >> testAddSuperSetUp [
-	class := self createTestCaseNamed: #ChanelTestClass.
-
 	class compile: 'setUp
   self assert: true'.
 
@@ -54,8 +83,6 @@ ChanelEnsureSuperIsCalledCleanerTest >> testAddSuperSetUp [
 
 { #category : #'tests - teardown' }
 ChanelEnsureSuperIsCalledCleanerTest >> testAddSuperTearDown [
-	class := self createTestCaseNamed: #ChanelTestClass.
-
 	class compile: 'tearDown
   self assert: true'.
 
@@ -75,8 +102,6 @@ ChanelEnsureSuperIsCalledCleanerTest >> testAddSuperTearDown [
 
 { #category : #'tests - initialize' }
 ChanelEnsureSuperIsCalledCleanerTest >> testDoesNotAddSuperInitializeOnClassSide [
-	class := self createClassNamed: #ChanelTestClass.
-
 	class class compile: 'initialize
 	self assert: true'.
 
@@ -96,8 +121,6 @@ ChanelEnsureSuperIsCalledCleanerTest >> testDoesNotAddSuperInitializeOnClassSide
 
 { #category : #'tests - initialize' }
 ChanelEnsureSuperIsCalledCleanerTest >> testDoesNotAddSuperInitializeWhenAlreadyThere [
-	class := self createClassNamed: #ChanelTestClass.
-
 	class compile: 'initialize
 	super initialize.
 	self assert: true'.
@@ -118,7 +141,7 @@ ChanelEnsureSuperIsCalledCleanerTest >> testDoesNotAddSuperInitializeWhenAlready
 
 { #category : #'tests - setup' }
 ChanelEnsureSuperIsCalledCleanerTest >> testDoesNotAddSuperSetUpIfClassIsNotATestCase [
-	class := self createClassNamed: #ChanelTestClass.
+	class := self createDefaultClass.
 
 	class compile: 'setUp
 	self assert: true'.
@@ -139,8 +162,6 @@ ChanelEnsureSuperIsCalledCleanerTest >> testDoesNotAddSuperSetUpIfClassIsNotATes
 
 { #category : #'tests - setup' }
 ChanelEnsureSuperIsCalledCleanerTest >> testDoesNotAddSuperSetUpIfEmptyMethod [
-	class := self createTestCaseNamed: #ChanelTestClass.
-
 	class compile: 'setUp
 '.
 
@@ -156,6 +177,30 @@ ChanelEnsureSuperIsCalledCleanerTest >> testDoesNotAddSuperSetUpIfEmptyMethod [
 
 	"In case there is nothing to change, we should *not* recompile the method, thus it should be identical."
 	self assert: oldMethod identicalTo: class >> #setUp
+]
+
+{ #category : #'tests - setup' }
+ChanelEnsureSuperIsCalledCleanerTest >> testDoesNotAddSuperSetUpInTrait [
+	| trait |
+	trait := self createDefaultTrait.
+	
+	class setTraitComposition: trait.
+
+	trait compile: 'setUp
+  self assert: true'.
+
+	oldMethod := trait >> #setUp.
+
+	self runCleaner.
+
+	self
+		assert: (trait >> #setUp) sourceCode
+		equals: 'setUp
+  self assert: true'.
+
+	self assert: (trait localSelectors includes: #setUp).
+	self deny: (class localSelectors includes: #setUp)
+
 ]
 
 { #category : #'tests - setup' }
@@ -178,8 +223,6 @@ ChanelEnsureSuperIsCalledCleanerTest >> testDoesNotAddSuperSetUpOnClassSide [
 
 { #category : #'tests - setup' }
 ChanelEnsureSuperIsCalledCleanerTest >> testDoesNotAddSuperSetUpWhenAlreadyThere [
-	class := self createTestCaseNamed: #ChanelTestClass.
-
 	class compile: 'setUp
 	super setUp.
 	self assert: true'.
@@ -200,7 +243,7 @@ ChanelEnsureSuperIsCalledCleanerTest >> testDoesNotAddSuperSetUpWhenAlreadyThere
 
 { #category : #'tests - teardown' }
 ChanelEnsureSuperIsCalledCleanerTest >> testDoesNotAddSuperTearDownIfClassIsNotATestCase [
-	class := self createClassNamed: #ChanelTestClass.
+	class := self createDefaultClass.
 
 	class compile: 'tearDown
 	self assert: true'.
@@ -221,8 +264,6 @@ ChanelEnsureSuperIsCalledCleanerTest >> testDoesNotAddSuperTearDownIfClassIsNotA
 
 { #category : #'tests - teardown' }
 ChanelEnsureSuperIsCalledCleanerTest >> testDoesNotAddSuperTearDownIfEmptyMethod [
-	class := self createTestCaseNamed: #ChanelTestClass.
-
 	class compile: 'tearDown
 '.
 
@@ -238,6 +279,30 @@ ChanelEnsureSuperIsCalledCleanerTest >> testDoesNotAddSuperTearDownIfEmptyMethod
 
 	"In case there is nothing to change, we should *not* recompile the method, thus it should be identical."
 	self assert: oldMethod identicalTo: class >> #tearDown
+]
+
+{ #category : #'tests - teardown' }
+ChanelEnsureSuperIsCalledCleanerTest >> testDoesNotAddSuperTearDownInTrait [
+	| trait |
+	trait := self createDefaultTrait.
+	
+	class setTraitComposition: trait.
+
+	trait compile: 'tearDown
+  self assert: true'.
+
+	oldMethod := trait >> #tearDown.
+
+	self runCleaner.
+
+	self
+		assert: (trait >> #tearDown) sourceCode
+		equals: 'tearDown
+  self assert: true'.
+
+	self assert: (trait localSelectors includes: #tearDown).
+	self deny: (class localSelectors includes: #tearDown)
+
 ]
 
 { #category : #'tests - teardown' }
@@ -260,8 +325,6 @@ ChanelEnsureSuperIsCalledCleanerTest >> testDoesNotAddSuperTearDownOnClassSide [
 
 { #category : #'tests - teardown' }
 ChanelEnsureSuperIsCalledCleanerTest >> testDoesNotAddSuperTearDownWhenAlreadyThere [
-	class := self createTestCaseNamed: #ChanelTestClass.
-
 	class compile: 'tearDown
 	self assert: true.
 	super tearDown'.
@@ -282,8 +345,6 @@ ChanelEnsureSuperIsCalledCleanerTest >> testDoesNotAddSuperTearDownWhenAlreadyTh
 
 { #category : #'tests - initialize' }
 ChanelEnsureSuperIsCalledCleanerTest >> testDoesNotCreateSuperInitializeInEmptyMethod [
-	class := self createClassNamed: #ChanelTestClass.
-
 	class compile: 'initialize
 '.
 
@@ -303,8 +364,6 @@ ChanelEnsureSuperIsCalledCleanerTest >> testDoesNotCreateSuperInitializeInEmptyM
 
 { #category : #'tests - initialize' }
 ChanelEnsureSuperIsCalledCleanerTest >> testDoesNotMoveSuperInitializeIfNotTheFirstStatement [
-	class := self createClassNamed: #ChanelTestClass.
-
 	class compile: 'initialize
 	self assert: true.
 	super initialize'.
@@ -326,8 +385,6 @@ ChanelEnsureSuperIsCalledCleanerTest >> testDoesNotMoveSuperInitializeIfNotTheFi
 
 { #category : #'tests - setup' }
 ChanelEnsureSuperIsCalledCleanerTest >> testMoveSuperSetUpIfNotFirstStatement [
-	class := self createTestCaseNamed: #ChanelTestClass.
-
 	class compile: 'setUp
   self assert: true.
   super setUp'.
@@ -349,8 +406,6 @@ ChanelEnsureSuperIsCalledCleanerTest >> testMoveSuperSetUpIfNotFirstStatement [
 
 { #category : #'tests - teardown' }
 ChanelEnsureSuperIsCalledCleanerTest >> testMoveSuperTearDownIfNotLastStatement [
-	class := self createTestCaseNamed: #ChanelTestClass.
-
 	class compile: 'tearDown
   super tearDown.
   self assert: true'.

--- a/src/Chanel-Tests/ChanelMethodsOnlyCallingSuperCleanerTest.class.st
+++ b/src/Chanel-Tests/ChanelMethodsOnlyCallingSuperCleanerTest.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #running }
 ChanelMethodsOnlyCallingSuperCleanerTest >> setUp [
 	super setUp.
-	class := self createClassNamed: #ChanelMethodOnlyCallingSuperFake
+	class := self createDefaultClass
 ]
 
 { #category : #tests }
@@ -139,6 +139,24 @@ ChanelMethodsOnlyCallingSuperCleanerTest >> testRemoveMethodOnlyCollingSuperEven
 	self runCleaner.
 
 	self deny: (class localSelectors includes: #initialize)
+]
+
+{ #category : #tests }
+ChanelMethodsOnlyCallingSuperCleanerTest >> testRemoveMethodOnlyCollingSuperInTrait [
+	| trait |
+	trait := self createDefaultTrait.
+	
+	class setTraitComposition: trait.
+	
+	trait
+		compile:
+			'initialize
+  super initialize'.
+
+	self runCleaner.
+
+	self deny: (class localSelectors includes: #initialize).
+	self deny: (trait localSelectors includes: #initialize)
 ]
 
 { #category : #tests }

--- a/src/Chanel-Tests/ChanelNilAssignationInInitializeCleanerTest.class.st
+++ b/src/Chanel-Tests/ChanelNilAssignationInInitializeCleanerTest.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #running }
 ChanelNilAssignationInInitializeCleanerTest >> setUp [
 	super setUp.
-	class := self createClassNamed: #ChanelNilAssignationInIntializeFake
+	class := self createDefaultClass
 ]
 
 { #category : #tests }
@@ -67,6 +67,31 @@ ChanelNilAssignationInInitializeCleanerTest >> testRemoveNilAssigment [
 		equals:
 			'initialize
   super initialize'
+]
+
+{ #category : #tests }
+ChanelNilAssignationInInitializeCleanerTest >> testRemoveNilAssigmentInTrait [
+	| trait |
+	trait := self createDefaultTrait.
+	
+	class setTraitComposition: trait.
+	
+	trait
+		compile:
+			'initialize
+  super initialize.
+  test := nil'.
+
+	self runCleaner.
+
+	self
+		assert: (trait >> #initialize) sourceCode
+		equals:
+			'initialize
+  super initialize'.
+
+	self deny: (class localSelectors includes: #initialize).
+	self assert: (trait localSelectors includes: #initialize)
 ]
 
 { #category : #tests }

--- a/src/Chanel-Tests/ChanelProtocolsCleanerTest.class.st
+++ b/src/Chanel-Tests/ChanelProtocolsCleanerTest.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #running }
 ChanelProtocolsCleanerTest >> setUp [
 	super setUp.
-	class := self createClassNamed: #ChanelProtocolsFake
+	class := self createDefaultClass
 ]
 
 { #category : #tests }
@@ -29,6 +29,21 @@ ChanelProtocolsCleanerTest >> testMethodInSpecificProtocol [
 	self runCleaner.
 	
 	self assert: (class >> #initialize) protocol equals: 'initialization'
+]
+
+{ #category : #tests }
+ChanelProtocolsCleanerTest >> testMethodInSpecificProtocolInTrait [
+	| trait |
+	trait := self createDefaultTrait.
+
+	trait compile: 'initialize' classified: 'random'.
+
+	self runCleaner.
+
+	self assert: (trait >> #initialize) protocol equals: 'initialization'.
+
+	self deny: (class localSelectors includes: #initialize).
+	self assert: (trait localSelectors includes: #initialize)
 ]
 
 { #category : #tests }
@@ -60,7 +75,7 @@ ChanelProtocolsCleanerTest >> testMethodInSpecificProtocolOnClassSide [
 
 { #category : #tests }
 ChanelProtocolsCleanerTest >> testTestMethodInSpecificProtocol [
-	class := self createTestCaseNamed: #ChanelProtocolsFake.
+	class := self createDefaultTestClass.
 	class compile: 'setUp' classified: 'random'.
 	
 	self runCleaner.
@@ -70,7 +85,7 @@ ChanelProtocolsCleanerTest >> testTestMethodInSpecificProtocol [
 
 { #category : #tests }
 ChanelProtocolsCleanerTest >> testTestMethodInSpecificProtocolNotUpdatedIfExtension [
-	class := self createTestCaseNamed: #ChanelProtocolsFake.
+	class := self createDefaultTestClass.
 	class compile: 'setUp' classified: self extensionProtocol.
 
 	self runCleaner.
@@ -89,7 +104,7 @@ ChanelProtocolsCleanerTest >> testTestMethodInSpecificProtocolNotUpdatedIfNotInT
 
 { #category : #tests }
 ChanelProtocolsCleanerTest >> testTestMethodInSpecificProtocolNotUpdatedIfNotInTheList [
-	class := self createTestCaseNamed: #ChanelProtocolsFake.
+	class := self createDefaultTestClass.
 	class compile: 'toto' classified: 'random'.
 
 	self runCleaner.
@@ -98,8 +113,26 @@ ChanelProtocolsCleanerTest >> testTestMethodInSpecificProtocolNotUpdatedIfNotInT
 ]
 
 { #category : #tests }
+ChanelProtocolsCleanerTest >> testTestMethodInSpecificProtocolNotUpdatedInTrait [
+	| trait |
+	trait := self createDefaultTrait.
+	class := self createDefaultTestClass.
+	
+	class setTraitComposition: trait.
+
+	trait compile: 'setUp' classified: 'random'.
+	
+	self runCleaner.
+	
+	self assert: (trait >> #setUp) protocol equals: 'random'.
+	
+	self deny: (class localSelectors includes: #setUp).
+	self assert: (trait localSelectors includes: #setUp)
+]
+
+{ #category : #tests }
 ChanelProtocolsCleanerTest >> testTestMethodsAreInRightProtocol [
-	class := self createTestCaseNamed: #ChanelProtocolsFake.
+	class := self createDefaultTestClass.
 	class compile: 'testMethod' classified: 'not a test'.
 	
 	self runCleaner.
@@ -109,7 +142,7 @@ ChanelProtocolsCleanerTest >> testTestMethodsAreInRightProtocol [
 
 { #category : #tests }
 ChanelProtocolsCleanerTest >> testTestMethodsProtocolAreNotUpdateIfExtension [
-	class := self createTestCaseNamed: #ChanelProtocolsFake.
+	class := self createDefaultTestClass.
 	class compile: 'testMethod' classified: self extensionProtocol.
 	
 	self runCleaner.
@@ -128,7 +161,7 @@ ChanelProtocolsCleanerTest >> testTestMethodsProtocolAreNotUpdateIfNotInTestCase
 
 { #category : #tests }
 ChanelProtocolsCleanerTest >> testTestMethodsProtocolAreNotUpdateIfStartingByTest [
-	class := self createTestCaseNamed: #ChanelProtocolsFake.
+	class := self createDefaultTestClass.
 	class compile: 'testMethod' classified: 'test - protocols'.
 	
 	self runCleaner.
@@ -143,6 +176,23 @@ ChanelProtocolsCleanerTest >> testUpdateCloseProtocol [
 	self runCleaner.
 	
 	self assert: (class >> #method) protocol equals: 'instance creation'
+]
+
+{ #category : #tests }
+ChanelProtocolsCleanerTest >> testUpdateCloseProtocolInTrait [
+	| trait |
+	trait := self createDefaultTrait.
+	
+	class setTraitComposition: trait.
+	
+	trait compile: 'method' classified: 'instance-creation'.
+	
+	self runCleaner.
+	
+	self assert: (trait >> #method) protocol equals: 'instance creation'.
+
+	self deny: (class localSelectors includes: #method ).
+	self assert: (trait localSelectors includes: #method)
 ]
 
 { #category : #tests }

--- a/src/Chanel-Tests/ChanelTestCaseNameCleanerTest.class.st
+++ b/src/Chanel-Tests/ChanelTestCaseNameCleanerTest.class.st
@@ -15,7 +15,7 @@ ChanelTestCaseNameCleanerTest >> testRenameTestCaseEndingWithTests [
 
 	self runCleaner.
 
-	self class environment at: 'ChanelMockTests' asSymbol ifPresent: [ :class | self fail ].
+	self class environment at: 'ChanelMockTests' asSymbol ifPresent: [ :c | self fail ].
 	self class environment at: 'ChanelMockTest' asSymbol ifAbsent: [ self fail ]
 ]
 
@@ -37,15 +37,15 @@ ChanelTestCaseNameCleanerTest >> testRenameTestCaseEndingWithTestsUpdateReferenc
 
 	self class environment
 		at: 'ChanelMockTest' asSymbol
-		ifPresent: [ :class | 
+		ifPresent: [ :c | 
 			self
-				assert: (class >> #test1) sourceCode
+				assert: (c >> #test1) sourceCode
 				equals:
 					'test1
 	^ ChanelMockTest'.
 
 			self
-				assert: (class >> #test2) sourceCode
+				assert: (c >> #test2) sourceCode
 				equals:
 					'test2
 	^ #ChanelMockTest' ]
@@ -74,7 +74,20 @@ ChanelTestCaseNameCleanerTest >> testShouldNotRenameNonTestCaseEndingWithTests [
 
 	"The class should not be renamed since it inherits from Object and not TestCase."
 	self class environment at: 'ChanelMockTests' asSymbol ifAbsent: [ self fail ].
-	self class environment at: 'ChanelMockTest' asSymbol ifPresent: [ :class | self fail ]
+	self class environment at: 'ChanelMockTest' asSymbol ifPresent: [ :c | self fail ]
+]
+
+{ #category : #tests }
+ChanelTestCaseNameCleanerTest >> testShouldNotRenameNonTraitEndingWithTests [
+	"/!\ /!\ We use #asSymbol instead of writing symbols because the renaming will update the references in the image, thus, it will rename the symbols in the test. /!\ /!\ "
+
+	self createTraitNamed: 'TChanelMockTests' asSymbol.
+
+	self runCleaner.
+
+	"The class should not be renamed since it inherits from Object and not TestCase."
+	self class environment at: 'TChanelMockTests' asSymbol ifAbsent: [ self fail ].
+	self class environment at: 'TChanelMockTest' asSymbol ifPresent: [ :c | self fail ]
 ]
 
 { #category : #tests }

--- a/src/Chanel-Tests/ChanelTestEqualityCleanerTest.class.st
+++ b/src/Chanel-Tests/ChanelTestEqualityCleanerTest.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #running }
 ChanelTestEqualityCleanerTest >> setUp [
 	super setUp.
-	class := self createTestCaseNamed: #ChanelEqualityTestCase
+	class := self createDefaultTestClass
 ]
 
 { #category : #tests }
@@ -93,6 +93,30 @@ ChanelTestEqualityCleanerTest >> testDoesNotRemoveExtensions [
 ]
 
 { #category : #tests }
+ChanelTestEqualityCleanerTest >> testDoesNotReplaceInTraits [
+	| trait |
+	trait := self createDefaultTrait.
+
+	class setTraitComposition: trait.
+
+	trait
+		compile:
+			('{1}
+  {2}' format: {self selector . 'self assert: 3 = 2'}).
+
+	self runCleaner.
+
+	self
+		assert: (trait >> self selector) sourceCode
+		equals:
+			('{1}
+  {2}' format: {self selector . 'self assert: 3 = 2'}).
+
+	self assert: (trait localSelectors includes: self selector).
+	self deny: (class localSelectors includes: self selector)
+]
+
+{ #category : #tests }
 ChanelTestEqualityCleanerTest >> testReplacementOnClassSide [
 	class class
 		compile:
@@ -112,7 +136,7 @@ ChanelTestEqualityCleanerTest >> testReplacementOnClassSide [
 ChanelTestEqualityCleanerTest >> testShouldNotReplaceIfNotATestCase [
 	"We only replace the assertion of TestCase because other objects are much poorer in term of assertions."
 
-	class := self createClassNamed: #ChanelEqualityNotTestCase.
+	class := self createDefaultClass.
 
 	class
 		compile:

--- a/src/Chanel-Tests/ChanelUnreadTemporaryCleanerTest.class.st
+++ b/src/Chanel-Tests/ChanelUnreadTemporaryCleanerTest.class.st
@@ -10,7 +10,7 @@ Class {
 { #category : #running }
 ChanelUnreadTemporaryCleanerTest >> setUp [
 	super setUp.
-	class := self createClassNamed: #ChanelUnreadTemporaryFake
+	class := self createDefaultClass
 ]
 
 { #category : #tests }
@@ -42,7 +42,7 @@ ChanelUnreadTemporaryCleanerTest >> testDoesNotRemoveTemporaryReadFromDeeperScop
 
 { #category : #tests }
 ChanelUnreadTemporaryCleanerTest >> testDontRemoveTemporaryRead [
-		| oldMethod |
+	| oldMethod |
 	class
 		compile:
 			'testMethod
@@ -63,12 +63,12 @@ ChanelUnreadTemporaryCleanerTest >> testDontRemoveTemporaryRead [
   ^test'.
 
 	"We should not have recompiled the method if we do not clean it."
-	self assert: (class >> #testMethod) identicalTo: oldMethod
+	self assert: class >> #testMethod identicalTo: oldMethod
 ]
 
 { #category : #tests }
 ChanelUnreadTemporaryCleanerTest >> testRemoveTemporaries [
-		class
+	class
 		compile:
 			'testMethod
   | test test2 |
@@ -89,7 +89,7 @@ ChanelUnreadTemporaryCleanerTest >> testRemoveTemporaries [
 
 { #category : #tests }
 ChanelUnreadTemporaryCleanerTest >> testRemoveTemporariesOnClassSide [
-		class class
+	class class
 		compile:
 			'testMethod
   | test test2 |
@@ -110,7 +110,7 @@ ChanelUnreadTemporaryCleanerTest >> testRemoveTemporariesOnClassSide [
 
 { #category : #tests }
 ChanelUnreadTemporaryCleanerTest >> testRemoveTemporary [
-		class
+	class
 		compile:
 			'testMethod
   | test |
@@ -129,7 +129,7 @@ ChanelUnreadTemporaryCleanerTest >> testRemoveTemporary [
 
 { #category : #tests }
 ChanelUnreadTemporaryCleanerTest >> testRemoveTemporaryFromDeeperScope [
-		class
+	class
 		compile:
 			'testMethod
   true ifTrue: [ | test |
@@ -149,7 +149,7 @@ ChanelUnreadTemporaryCleanerTest >> testRemoveTemporaryFromDeeperScope [
 
 { #category : #tests }
 ChanelUnreadTemporaryCleanerTest >> testRemoveTemporaryFromDeeperScopes [
-		class
+	class
 		compile:
 			'testMethod
   true ifTrue: [ | test |
@@ -171,7 +171,7 @@ ChanelUnreadTemporaryCleanerTest >> testRemoveTemporaryFromDeeperScopes [
 
 { #category : #tests }
 ChanelUnreadTemporaryCleanerTest >> testRemoveTemporaryFromDeeperScopesWithOneRead [
-		class
+	class
 		compile:
 			'testMethod
   true ifTrue: [ | test |
@@ -191,4 +191,31 @@ ChanelUnreadTemporaryCleanerTest >> testRemoveTemporaryFromDeeperScopesWithOneRe
         test := self tata.
         ^test ].
   ^#one'
+]
+
+{ #category : #tests }
+ChanelUnreadTemporaryCleanerTest >> testRemoveTemporaryInTrait [
+	| trait |
+	trait := self createDefaultTrait.
+	
+	class setTraitComposition: trait.
+
+	trait
+		compile:
+			'testMethod
+  | test |
+  test := self toto.
+  ^#one'.
+
+	self runCleaner.
+
+	self
+		assert: (trait >> #testMethod) sourceCode
+		equals:
+			'testMethod
+  self toto.
+  ^#one'.
+
+	self deny: (class localSelectors includes: #testMethod).
+	self assert: (trait localSelectors includes: #testMethod)
 ]


### PR DESCRIPTION
Add tests on trait cleanings.

Fixes #23