### PR TITLE
27-Should-not-rewrite-return-with-the-call-of-the-self-method-infinite-loop

### DIFF
--- a/src/Chanel-Tests/ChanelConditionalSimplifierCleanerTest.class.st
+++ b/src/Chanel-Tests/ChanelConditionalSimplifierCleanerTest.class.st
@@ -13,7 +13,7 @@ ChanelConditionalSimplifierCleanerTest >> setUp [
 	class := self createDefaultTestClass
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 ChanelConditionalSimplifierCleanerTest >> testDoesNotReplaceIfItIntroduceAnInfinitLoop [
 	| oldMethod |
 	class
@@ -34,7 +34,7 @@ ChanelConditionalSimplifierCleanerTest >> testDoesNotReplaceIfItIntroduceAnInfin
 	self assert: class >> #ifNotNil: identicalTo: oldMethod
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #tests }
 ChanelConditionalSimplifierCleanerTest >> testDoesNotReplaceIfItIntroduceAnInfinitLoop2 [
 	| oldMethod |
 	class

--- a/src/Chanel-Tests/ChanelConditionalSimplifierCleanerTest.class.st
+++ b/src/Chanel-Tests/ChanelConditionalSimplifierCleanerTest.class.st
@@ -13,6 +13,48 @@ ChanelConditionalSimplifierCleanerTest >> setUp [
 	class := self createDefaultTestClass
 ]
 
+{ #category : #'as yet unclassified' }
+ChanelConditionalSimplifierCleanerTest >> testDoesNotReplaceIfItIntroduceAnInfinitLoop [
+	| oldMethod |
+	class
+		compile:
+			'ifNotNil: aBlock
+  ^self isNil ifFalse: aBlock'.
+
+	oldMethod := class >> #ifNotNil:.
+
+	self runCleaner.
+
+	self
+		assert: (class >> #ifNotNil:) sourceCode
+		equals:
+			'ifNotNil: aBlock
+  ^self isNil ifFalse: aBlock'.
+
+	self assert: class >> #ifNotNil: identicalTo: oldMethod
+]
+
+{ #category : #'as yet unclassified' }
+ChanelConditionalSimplifierCleanerTest >> testDoesNotReplaceIfItIntroduceAnInfinitLoop2 [
+	| oldMethod |
+	class
+		compile:
+			'ifNotNil: aBlock
+  self isNil ifFalse: aBlock'.
+
+	oldMethod := class >> #ifNotNil:.
+
+	self runCleaner.
+
+	self
+		assert: (class >> #ifNotNil:) sourceCode
+		equals:
+			'ifNotNil: aBlock
+  self isNil ifFalse: aBlock'.
+
+	self assert: class >> #ifNotNil: identicalTo: oldMethod
+]
+
 { #category : #tests }
 ChanelConditionalSimplifierCleanerTest >> testIsNilIfFalse [
 	self assert: '10 isNil ifFalse: [ false ]' isRewrittenAs: '10 ifNotNil: [ false ]'

--- a/src/Chanel/CompiledMethod.extension.st
+++ b/src/Chanel/CompiledMethod.extension.st
@@ -22,6 +22,10 @@ CompiledMethod >> hasPragma [
 CompiledMethod >> installAST [
 	"In Chanel we update some ASTs. This method install the updated AST."
 
+	"In case the update of ast introduce a direct call to self, we do not take the risk to update the AST to not introduce an infinite loop.
+	Instead we discard the AST cache."
+	(self ast sendNodes anySatisfy: [ :message | message isSelfSendTo: self selector ]) ifTrue: [ ^ ASTCache reset ].
+
 	self ast install
 ]
 

--- a/src/Chanel/RBMessageNode.extension.st
+++ b/src/Chanel/RBMessageNode.extension.st
@@ -1,6 +1,11 @@
 Extension { #name : #RBMessageNode }
 
 { #category : #'*Chanel' }
+RBMessageNode >> isSelfSendTo: aSelector [
+	^ self isSelfSend and: [  self selector = aSelector ]
+]
+
+{ #category : #'*Chanel' }
 RBMessageNode >> isSuperSendTo: aSelector [
 	^ self isSuperSend and: [  self selector = aSelector ]
 ]


### PR DESCRIPTION
Add a guard when recompiling a method to not introduce a call to self.

Fixes #27