### PR TITLE
48-TestCase-renaming-should-check-there-is-not-another-class-with-the-same-name-in-the-system

### DIFF
--- a/resources/doc/documentation.md
+++ b/resources/doc/documentation.md
@@ -155,9 +155,10 @@ Chanel rename each test case ending with `Tests` te end with `Test` since this i
 *Conditions for the cleanings to by applied:*
 - The class needs to be a subclass of TestCase.
 - The class name needs to end with `Tests`.
+- The system should not contain a class with the same name without the final `s`.
 
 *Warnings:*
-This might cause trouble if you have a test case end with `Test` and another class with the same name ending with `Tests`.
+This cleaning should not have any counter indication.
 
 ### Ensure right super are call
 
@@ -208,7 +209,6 @@ Remove each methods only doing a super call. This does not remove methods with p
 - The method should not have any pragma.
 
 *Warnings:*
-
 This might remove methods added just to add comments in a subclass.
 
 ### Remove unread temporaries

--- a/src/Chanel-Tests/ChanelTestCaseNameCleanerTest.class.st
+++ b/src/Chanel-Tests/ChanelTestCaseNameCleanerTest.class.st
@@ -53,6 +53,21 @@ ChanelTestCaseNameCleanerTest >> testRenameTestCaseEndingWithTestsUpdateReferenc
 ]
 
 { #category : #tests }
+ChanelTestCaseNameCleanerTest >> testShouldNotRenameIfTheNewClassNameAlreadyExistsInTheSystem [
+	"/!\ /!\ We use #asSymbol instead of writing symbols because the renaming will update the references in the image, thus, it will rename the symbols in the test. /!\ /!\ "
+
+	self createTestCaseNamed: 'ChanelMockTests' asSymbol.
+	self createTestCaseNamed: 'ChanelMockTest' asSymbol.
+
+	"The class should not be renamed since the right name already exists in the system."
+
+	self shouldnt: [ self runCleaner ] raise: Error.
+
+	self class environment at: 'ChanelMockTest' asSymbol ifAbsent: [ self fail ].
+	self class environment at: 'ChanelMockTests' asSymbol ifAbsent: [ self fail ]
+]
+
+{ #category : #tests }
 ChanelTestCaseNameCleanerTest >> testShouldNotRenameNonTestCaseEndingWithTest [
 	"/!\ /!\ We use #asSymbol instead of writing symbols because the renaming will update the references in the image, thus, it will rename the symbols in the test. /!\ /!\ "
 

--- a/src/Chanel/ChanelTestCaseNameCleaner.class.st
+++ b/src/Chanel/ChanelTestCaseNameCleaner.class.st
@@ -17,9 +17,14 @@ ChanelTestCaseNameCleaner class >> priority [
 
 { #category : #cleaning }
 ChanelTestCaseNameCleaner >> clean [
-	self configuration definedTestCases
-		select: [ :class | class name endsWith: 'Tests' ]
-		thenDo: [ :class | 
-			('Renaming ' , class name , ' to ' , class name allButLast) record.
-			(RBRenameClassRefactoring rename: class to: class name allButLast) execute ]
+	self configuration definedTestCases iterator
+		| [ :class | class name endsWith: 'Tests' ] selectIt
+		| [ :class | self class environment hasClassNamed: class name allButLast ] rejectIt
+		> [ :class | self rename: class as: class name allButLast ] doIt
+]
+
+{ #category : #cleaning }
+ChanelTestCaseNameCleaner >> rename: class as: aString [
+	('Renaming ' , class name , ' to ' , aString) record.
+	(RBRenameClassRefactoring rename: class to: aString) execute
 ]


### PR DESCRIPTION
Do not rename a class if another of the same name already exists in the system.

Fixes #48