### PR TITLE
4-Add-parameter-to-set-the-minimal-version-of-Pharo-in-which-the-cleaned-project-should-work

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ Chanel perfume: packages using: { ChanelTestEqualityCleaner . ChanelProtocolsCl
 You can find the full list of cleaners running `ChanelAbstractCleaner cleaners asArray`.
 It is advised to keep the cleaner in the given order of this snippet since some of them needs to run before the others.
 
+A last parameter interesting to configure is the minimal Pharo version on which the project should work.
+*Chanel* contains cleaners that are using methods introduced only recent versions of Pharo. 
+Thus, to avoid to break projects running on older version of Pharo it is possible to define the minimal Pharo version on which the project should run.
+
+```Smalltalk
+Chanel perfume: packages forPharo: 6.
+
+Chanel perfume: packages using: { ChanelTestEqualityCleaner . ChanelProtocolsCleaner  } forPharo: 6.
+```
+
 > You can open playgrounds containing those snippets via the world menu once the project is installed.
 
 > **WARNING**: Some cleaning are making sense in most cases but might cause troubles in some edge cases. Please, read the documentation to see the list of possible problems it might introduce.

--- a/resources/doc/documentation.md
+++ b/resources/doc/documentation.md
@@ -22,6 +22,16 @@ Chanel perfume: packages using: { ChanelTestEqualityCleaner . ChanelProtocolsCl
 You can find the full list of cleaners running `ChanelAbstractCleaner cleaners asArray`.
 It is advised to keep the cleaner in the given order of this snippet since some of them needs to run before the others.
 
+A last parameter interesting to configure is the minimal Pharo version on which the project should work.
+*Chanel* contains cleaners that are using methods introduced only recent versions of Pharo. 
+Thus, to avoid to break projects running on older version of Pharo it is possible to define the minimal Pharo version on which the project should run.
+
+```Smalltalk
+Chanel perfume: packages forPharo: 6.
+
+Chanel perfume: packages using: { ChanelTestEqualityCleaner . ChanelProtocolsCleaner  } forPharo: 6.
+```
+
 > You can open playgrounds containing those snippets via the world menu once the project is installed.
 
 ## Logging changes
@@ -83,6 +93,7 @@ Here is the list of rewrites it will apply:
 
 *Warnings:*
 The danger of this cleaning happens on projects working in Pharo < 7. Some of this new assertions were introduced in Pharo 7.
+You can precise the minimal Pharo version on which the project should run to avoid the application of those rules.
 
 ### Clean protocols
 

--- a/src/Chanel-Tests/ChanelAbstractCleanerTest.class.st
+++ b/src/Chanel-Tests/ChanelAbstractCleanerTest.class.st
@@ -104,6 +104,23 @@ ChanelAbstractCleanerTest >> defaultTraitName [
 	^ ('T' , self defaultClassName) asSymbol
 ]
 
+{ #category : #helpers }
+ChanelAbstractCleanerTest >> deny: original isRewrittenForPharo: anInteger [
+	| oldMethod |
+	class ifNil: [ self error: 'To use this method you need to setup the class variable' ].
+
+	class
+		compile:
+			('{1}
+  {2}' format: {self selector . original}).
+
+	oldMethod := class >> self selector.
+
+	self runCleanerForPharo: anInteger.
+
+	self assert: class >> self selector identicalTo: oldMethod
+]
+
 { #category : #running }
 ChanelAbstractCleanerTest >> extensionProtocol [
 	^ '*' , extensionPackage name
@@ -112,6 +129,11 @@ ChanelAbstractCleanerTest >> extensionProtocol [
 { #category : #running }
 ChanelAbstractCleanerTest >> runCleaner [
 	Chanel perfume: {package} using: {self actualClass}
+]
+
+{ #category : #running }
+ChanelAbstractCleanerTest >> runCleanerForPharo: anInteger [
+	Chanel perfume: {package} using: {self actualClass} forPharo: anInteger
 ]
 
 { #category : #running }

--- a/src/Chanel-Tests/ChanelTestEqualityCleanerTest.class.st
+++ b/src/Chanel-Tests/ChanelTestEqualityCleanerTest.class.st
@@ -54,6 +54,11 @@ ChanelTestEqualityCleanerTest >> testAssertIdenticalToFalse2 [
 ]
 
 { #category : #tests }
+ChanelTestEqualityCleanerTest >> testAssertIdenticalToNotReplacedForPharo6 [
+	self deny: 'self assert: 3 == 2' isRewrittenForPharo: 6
+]
+
+{ #category : #tests }
 ChanelTestEqualityCleanerTest >> testAssertIdenticalToTrue [
 	self assert: 'self assert: 3 == true' isRewrittenAs: 'self assert: 3'
 ]
@@ -79,6 +84,11 @@ ChanelTestEqualityCleanerTest >> testDenyEqualsFalse2 [
 ]
 
 { #category : #tests }
+ChanelTestEqualityCleanerTest >> testDenyEqualsNotReplacedForPharo6 [
+	self deny: 'self deny: 3 = 2' isRewrittenForPharo: 6
+]
+
+{ #category : #tests }
 ChanelTestEqualityCleanerTest >> testDenyEqualsTrue [
 	self assert: 'self deny: 3 = true' isRewrittenAs: 'self deny: 3'
 ]
@@ -101,6 +111,11 @@ ChanelTestEqualityCleanerTest >> testDenyIdenticalToFalse [
 { #category : #tests }
 ChanelTestEqualityCleanerTest >> testDenyIdenticalToFalse2 [
 	self assert: 'self deny: 3 identicalTo: false' isRewrittenAs: 'self assert: 3'
+]
+
+{ #category : #tests }
+ChanelTestEqualityCleanerTest >> testDenyIdenticalToNotReplacedForPharo6 [
+	self deny: 'self deny: 3 == 2' isRewrittenForPharo: 6
 ]
 
 { #category : #tests }

--- a/src/Chanel/Chanel.class.st
+++ b/src/Chanel/Chanel.class.st
@@ -34,7 +34,8 @@ Class {
 	#name : #Chanel,
 	#superclass : #Object,
 	#instVars : [
-		'packages'
+		'packages',
+		'minimalPharoVersion'
 	],
 	#classVars : [
 		'Logger'
@@ -83,13 +84,24 @@ Chanel perfume: packages using: \{
 
 { #category : #cleaning }
 Chanel class >> perfume: aCollectionOfPackages [
-	^ self perfume: aCollectionOfPackages using: ChanelAbstractCleaner cleaners
+	^ self perfume: aCollectionOfPackages forPharo: Float infinity
+]
+
+{ #category : #cleaning }
+Chanel class >> perfume: aCollectionOfPackages forPharo: anInteger [
+	^ self perfume: aCollectionOfPackages using: ChanelAbstractCleaner cleaners forPharo: anInteger
 ]
 
 { #category : #cleaning }
 Chanel class >> perfume: aCollectionOfPackages using: aCollectionOfCleaners [
+	^ self perfume: aCollectionOfPackages using: aCollectionOfCleaners forPharo: Float infinity
+]
+
+{ #category : #cleaning }
+Chanel class >> perfume: aCollectionOfPackages using: aCollectionOfCleaners forPharo: anInteger [
 	^ self new
 		packages: aCollectionOfPackages;
+		minimalPharoVersion: anInteger;
 		cleanUsing: aCollectionOfCleaners
 ]
 
@@ -121,6 +133,11 @@ Chanel class >> worldMenuOn: aBuilder [
 
 { #category : #cleaning }
 Chanel >> cleanUsing: cleaners [
+	self cleanWithSelectedCleaners: (cleaners select: [ :each | each isAvailableForPharo: self minimalPharoVersion ])
+]
+
+{ #category : #cleaning }
+Chanel >> cleanWithSelectedCleaners: cleaners [
 	TinyCurrentLogger
 		value: self class logger
 		during: [ self
@@ -156,6 +173,21 @@ Chanel >> localMethods [
 { #category : #accessing }
 Chanel >> localMethodsWithoutExtensions [
 	^ self localMethods reject: #isExtension
+]
+
+{ #category : #accessing }
+Chanel >> minimalPharoVersion [
+	^ minimalPharoVersion
+]
+
+{ #category : #accessing }
+Chanel >> minimalPharoVersion: anObject [
+	minimalPharoVersion := anObject
+]
+
+{ #category : #accessing }
+Chanel >> packages [
+	^ packages
 ]
 
 { #category : #accessing }

--- a/src/Chanel/Chanel.class.st
+++ b/src/Chanel/Chanel.class.st
@@ -62,10 +62,11 @@ Chanel class >> openWorkspaceToCleanProject [
 	GTPlayground
 		openContents:
 			'projectName := ''Chanel''. "The project name in Iceberg"
+minimalPharoVersion := 9. "The minimal Pharo version on which the project should run. This disable some cleanings using API introduced in recent Pharo versions."
 			
 packages := ((IceRepository registry select: [ :e | e name = projectName ]) flatCollect: [ :e | e workingCopy packageNames collect: [:s | s asPackageIfAbsent: [ nil ] ]]) reject: #isNil.
 
-Chanel perfume: packages'
+Chanel perfume: packages forPharo: minimalPharoVersion'
 ]
 
 { #category : #'world menu' }
@@ -73,13 +74,17 @@ Chanel class >> openWorkspaceToCleanProjectWithSomeCleaners [
 	GTPlayground
 		openContents:
 			('projectName := ''Chanel''. "The project name in Iceberg"
+minimalPharoVersion := 9. "The minimal Pharo version on which the project should run. This disable some cleanings using API introduced in recent Pharo versions."
 			
 packages := ((IceRepository registry select: [ :e | e name = projectName ]) flatCollect: [ :e | e workingCopy packageNames collect: [:s | s asPackageIfAbsent: [ nil ] ]]) reject: #isNil.
 
-Chanel perfume: packages using: \{
-	{1}
-}' format: { '.
-	' join: (ChanelAbstractCleaner cleaners collect: #name) } )
+Chanel
+	perfume: packages
+	using: \{
+		{1}
+	}
+	forPharo: minimalPharoVersion' format: { '.
+		' join: (ChanelAbstractCleaner cleaners collect: #name) } )
 ]
 
 { #category : #cleaning }

--- a/src/Chanel/ChanelAbstractCleaner.class.st
+++ b/src/Chanel/ChanelAbstractCleaner.class.st
@@ -48,6 +48,11 @@ ChanelAbstractCleaner class >> isAbstract [
 	^ self = ChanelAbstractCleaner
 ]
 
+{ #category : #testing }
+ChanelAbstractCleaner class >> isAvailableForPharo: anInteger [
+	^ true
+]
+
 { #category : #accessing }
 ChanelAbstractCleaner class >> priority [
 	^ self subclassResponsibility
@@ -66,4 +71,9 @@ ChanelAbstractCleaner >> configuration [
 { #category : #accessing }
 ChanelAbstractCleaner >> configuration: anObject [
 	configuration := anObject
+]
+
+{ #category : #accessing }
+ChanelAbstractCleaner >> minimalPharoVersion [
+	^ self configuration minimalPharoVersion
 ]

--- a/src/Chanel/ChanelTestEqualityCleaner.class.st
+++ b/src/Chanel/ChanelTestEqualityCleaner.class.st
@@ -48,23 +48,26 @@ ChanelTestEqualityCleaner >> rewriter [
 		replace: '`@receiver deny: `@arg = true' with: '`@receiver deny: `@arg';
 		replace: '`@receiver assert: `@arg = false' with: '`@receiver deny: `@arg';
 		replace: '`@receiver deny: `@arg = false' with: '`@receiver assert: `@arg';
-		replace: '`@receiver assert: `@arg identicalTo: true' with: '`@receiver assert: `@arg';
-		replace: '`@receiver deny: `@arg identicalTo: true' with: '`@receiver deny: `@arg';
-		replace: '`@receiver assert: `@arg identicalTo: false' with: '`@receiver deny: `@arg';
-		replace: '`@receiver deny: `@arg identicalTo: false' with: '`@receiver assert: `@arg';
-		replace: '`@receiver assert: `@arg == true' with: '`@receiver assert: `@arg';
-		replace: '`@receiver deny: `@arg == true' with: '`@receiver deny: `@arg';
-		replace: '`@receiver assert: `@arg == false' with: '`@receiver deny: `@arg';
-		replace: '`@receiver deny: `@arg == false' with: '`@receiver assert: `@arg';
+
 		replace: '`@receiver assert: `@arg equals: true' with: '`@receiver assert: `@arg';
 		replace: '`@receiver deny: `@arg equals: true' with: '`@receiver deny: `@arg';
 		replace: '`@receiver assert: `@arg equals: false' with: '`@receiver deny: `@arg';
 		replace: '`@receiver deny: `@arg equals: false' with: '`@receiver assert: `@arg';
+
+		replace: '`@receiver assert: `@arg identicalTo: true' with: '`@receiver assert: `@arg';
+		replace: '`@receiver deny: `@arg identicalTo: true' with: '`@receiver deny: `@arg';
+		replace: '`@receiver assert: `@arg identicalTo: false' with: '`@receiver deny: `@arg';
+		replace: '`@receiver deny: `@arg identicalTo: false' with: '`@receiver assert: `@arg';
+
+		replace: '`@receiver assert: `@arg == true' with: '`@receiver assert: `@arg';
+		replace: '`@receiver deny: `@arg == true' with: '`@receiver deny: `@arg';
+		replace: '`@receiver assert: `@arg == false' with: '`@receiver deny: `@arg';
+		replace: '`@receiver deny: `@arg == false' with: '`@receiver assert: `@arg';
+
 		replace: '`@receiver assert: `@arg = `@arg2' with: '`@receiver assert: `@arg equals: `@arg2';
-		replace: '`@receiver deny: `@arg = `@arg2' with: '`@receiver deny: `@arg equals: `@arg2';
-		replace: '`@receiver assert: `@arg == `@arg2' with: '`@receiver assert: `@arg identicalTo: `@arg2';
-		replace: '`@receiver deny: `@arg == `@arg2' with: '`@receiver deny: `@arg identicalTo: `@arg2';
-		replace: '`@receiver assert: `@arg = true' with: '`@receiver assert: `@arg';
+		replace: '`@receiver deny: `@arg = `@arg2' with: '`@receiver deny: `@arg equals: `@arg2' when: [ :n | self minimalPharoVersion >= 7 ];
+		replace: '`@receiver assert: `@arg == `@arg2' with: '`@receiver assert: `@arg identicalTo: `@arg2' when: [ :n | self minimalPharoVersion >= 7 ];
+		replace: '`@receiver deny: `@arg == `@arg2' with: '`@receiver deny: `@arg identicalTo: `@arg2' when: [ :n | self minimalPharoVersion >= 7 ];
 		yourself
 ]
 


### PR DESCRIPTION
Add a parameter to configure the Pharo version on which the project should be able to run.

Fixes #4