### PR TITLE
16-Check-for-methods-in-traits-already-present-in-a-trait-they-use

### DIFF
--- a/resources/doc/documentation.md
+++ b/resources/doc/documentation.md
@@ -282,10 +282,10 @@ This might remove methods that were intentionally created with the flaw for test
 
 ### Remove duplicated methods from traits 
 
-If methods present on traits are duplicated in a classe using the trait, Chanel removes the duplicated version.
+If methods present on traits are duplicated in a classe or a trait using the trait, Chanel removes the duplicated version.
 
 *Conditions for the cleanings to by applied:*
-- The class of the method needs to use at least on trait
+- The class or trait of the method needs to use at least on trait
 - The method should have another method in the trait composition with the same name and the same AST.
 
 *Warnings:*

--- a/src/Chanel-Tests/ChanelDuplicatedMethodFromTraitCleanerTest.class.st
+++ b/src/Chanel-Tests/ChanelDuplicatedMethodFromTraitCleanerTest.class.st
@@ -161,3 +161,27 @@ ChanelDuplicatedMethodFromTraitCleanerTest >> testRemoveDuplicatedMethodFromTrai
 	self assert: (trait class localSelectors includes: #one).
 	self deny: (class class localSelectors includes: #one)
 ]
+
+{ #category : #tests }
+ChanelDuplicatedMethodFromTraitCleanerTest >> testRemoveDuplicatedMethodFromTraitUsingTrait [
+	| trait2 |
+	trait2 := self createTraitNamed: 'SecondTrait'.
+	trait setTraitComposition: trait2.
+	class setTraitComposition: trait.
+
+	trait2
+		compile:
+			'one
+	^ #one'.
+
+	trait
+		compile:
+			'one
+	^ #one'.
+
+	self runCleaner.
+
+	self assert: (trait2 localSelectors includes: #one).
+	self deny: (trait localSelectors includes: #one).
+	self deny: (class localSelectors includes: #one)
+]

--- a/src/Chanel/ChanelDuplicatedMethodFromTraitCleaner.class.st
+++ b/src/Chanel/ChanelDuplicatedMethodFromTraitCleaner.class.st
@@ -18,7 +18,6 @@ ChanelDuplicatedMethodFromTraitCleaner class >> priority [
 { #category : #cleaning }
 ChanelDuplicatedMethodFromTraitCleaner >> clean [
 	self configuration definedClasses iterator
-		| #isTrait rejectIt
 		| #hasTraitComposition selectIt
 		> #removeDuplicatedMethodsFromTrait doIt
 ]


### PR DESCRIPTION
Check for methods in traits already present in a trait they use

Fixes #16