### PR TITLE
63-Improve-nil-conditions-cleaner-to-have-better-rewrites

### DIFF
--- a/resources/doc/documentation.md
+++ b/resources/doc/documentation.md
@@ -152,6 +152,14 @@ Chanel simplifies conditionals. For example it will rewrite:
 | `x ifNil: nil` | `x` |
 | `x ifNil: nil ifNotNil: y` | `x ifNotNil: y` |
 | `x ifNotNil: y ifNil: nil` | `x ifNotNil: y` |
+| `x isNil ifTrue: [ nil ] ifFalse: y` | `x ifNotNil: y` |
+| `x isNil ifTrue: nil ifFalse: y` | `x ifNotNil: y` |
+| `x isNil ifFalse: y ifTrue: [ nil ]` | `x ifNotNil: y` |
+| `x isNil ifFalse: y ifTrue: nil` | `x ifNotNil: y` |
+| `x isNotNil ifTrue: y ifFalse: [ nil ]` | `x ifNotNil: y` |
+| `x isNotNil ifTrue: y ifFalse: nil` | `x ifNotNil: y` |
+| `x isNotNil ifFalse: [ nil ] ifTrue: y ` | `x ifNotNil: y` |
+| `x isNotNil ifFalse: nil ifTrue: y` | `x ifNotNil: y` |
 
 *Conditions for the cleanings to by applied:*
 - Can be applied on any classes and traits.

--- a/src/Chanel-Tests/ChanelNilConditionalSimplifierCleanerTest.class.st
+++ b/src/Chanel-Tests/ChanelNilConditionalSimplifierCleanerTest.class.st
@@ -96,6 +96,16 @@ ChanelNilConditionalSimplifierCleanerTest >> testIsNilIfFalseIfTrue [
 ]
 
 { #category : #tests }
+ChanelNilConditionalSimplifierCleanerTest >> testIsNilIfFalseIfTrue2 [
+	self assert: '10 isNil ifFalse: [ false ] ifTrue: [ nil ]' isRewrittenAs: '10 ifNotNil: [ false ]'
+]
+
+{ #category : #tests }
+ChanelNilConditionalSimplifierCleanerTest >> testIsNilIfFalseIfTrue3 [
+	self assert: '10 isNil ifFalse: [ false ] ifTrue: nil' isRewrittenAs: '10 ifNotNil: [ false ]'
+]
+
+{ #category : #tests }
 ChanelNilConditionalSimplifierCleanerTest >> testIsNilIfTrue [
 	self assert: '10 isNil ifTrue: [ false ]' isRewrittenAs: '10 ifNil: [ false ]'
 ]
@@ -103,6 +113,16 @@ ChanelNilConditionalSimplifierCleanerTest >> testIsNilIfTrue [
 { #category : #tests }
 ChanelNilConditionalSimplifierCleanerTest >> testIsNilIfTrueIfFalse [
 	self assert: '10 isNil ifTrue: [ false ] ifFalse: [ true ]' isRewrittenAs: '10 ifNil: [ false ] ifNotNil: [ true ]'
+]
+
+{ #category : #tests }
+ChanelNilConditionalSimplifierCleanerTest >> testIsNilIfTrueIfFalse2 [
+	self assert: '10 isNil ifTrue: [ nil ] ifFalse: [ true ]' isRewrittenAs: '10 ifNotNil: [ true ]'
+]
+
+{ #category : #tests }
+ChanelNilConditionalSimplifierCleanerTest >> testIsNilIfTrueIfFalse3 [
+	self assert: '10 isNil ifTrue: nil ifFalse: [ true ]' isRewrittenAs: '10 ifNotNil: [ true ]'
 ]
 
 { #category : #tests }
@@ -116,6 +136,16 @@ ChanelNilConditionalSimplifierCleanerTest >> testIsNotNilIfFalseIfTrue [
 ]
 
 { #category : #tests }
+ChanelNilConditionalSimplifierCleanerTest >> testIsNotNilIfFalseIfTrue2 [
+	self assert: '10 isNotNil ifFalse: [ nil ] ifTrue: [ true ]' isRewrittenAs: '10 ifNotNil: [ true ]'
+]
+
+{ #category : #tests }
+ChanelNilConditionalSimplifierCleanerTest >> testIsNotNilIfFalseIfTrue3 [
+	self assert: '10 isNotNil ifFalse: nil ifTrue: [ true ]' isRewrittenAs: '10 ifNotNil: [ true ]'
+]
+
+{ #category : #tests }
 ChanelNilConditionalSimplifierCleanerTest >> testIsNotNilIfTrue [
 	self assert: '10 isNotNil ifTrue: [ false ]' isRewrittenAs: '10 ifNotNil: [ false ]'
 ]
@@ -123,6 +153,16 @@ ChanelNilConditionalSimplifierCleanerTest >> testIsNotNilIfTrue [
 { #category : #tests }
 ChanelNilConditionalSimplifierCleanerTest >> testIsNotNilIfTrueIfFalse [
 	self assert: '10 isNotNil ifTrue: [ false ] ifFalse: [ true ]' isRewrittenAs: '10 ifNil: [ true ] ifNotNil: [ false ]'
+]
+
+{ #category : #tests }
+ChanelNilConditionalSimplifierCleanerTest >> testIsNotNilIfTrueIfFalse2 [
+	self assert: '10 isNotNil ifTrue: [ false ] ifFalse: [ nil ]' isRewrittenAs: '10 ifNotNil: [ false ]'
+]
+
+{ #category : #tests }
+ChanelNilConditionalSimplifierCleanerTest >> testIsNotNilIfTrueIfFalse3 [
+	self assert: '10 isNotNil ifTrue: [ false ] ifFalse: nil' isRewrittenAs: '10 ifNotNil: [ false ]'
 ]
 
 { #category : #tests }

--- a/src/Chanel/ChanelNilConditionalSimplifierCleaner.class.st
+++ b/src/Chanel/ChanelNilConditionalSimplifierCleaner.class.st
@@ -38,9 +38,21 @@ ChanelNilConditionalSimplifierCleaner >> rewriter [
 		replace: '`@receiver ifNil: [ nil ]' with: '`@receiver';
 		replace: '`@receiver ifNil: [ nil ] ifNotNil: `@arg' with: '`@receiver ifNotNil: `@arg';
 		replace: '`@receiver ifNotNil: `@arg ifNil: [ nil ]' with: '`@receiver ifNotNil: `@arg';
+
 		replace: '`@receiver ifNil: nil' with: '`@receiver';
 		replace: '`@receiver ifNil: nil ifNotNil: `@arg' with: '`@receiver ifNotNil: `@arg';
 		replace: '`@receiver ifNotNil: `@arg ifNil: nil' with: '`@receiver ifNotNil: `@arg';
+		
+		replace: '`@receiver isNil ifTrue: [ nil ] ifFalse: `@arg' with: '`@receiver ifNotNil: `@arg';
+		replace: '`@receiver isNil ifTrue: nil ifFalse: `@arg' with: '`@receiver ifNotNil: `@arg';
+		replace: '`@receiver isNil ifFalse: `@arg ifTrue: [ nil ]' with: '`@receiver ifNotNil: `@arg';
+		replace: '`@receiver isNil ifFalse: `@arg ifTrue: nil' with: '`@receiver ifNotNil: `@arg';
+		
+		replace: '`@receiver isNotNil ifTrue: `@arg ifFalse: [ nil ]' with: '`@receiver ifNotNil: `@arg';
+		replace: '`@receiver isNotNil ifTrue: `@arg ifFalse: nil' with: '`@receiver ifNotNil: `@arg';
+		replace: '`@receiver isNotNil ifFalse: [ nil ] ifTrue: `@arg ' with: '`@receiver ifNotNil: `@arg';
+		replace: '`@receiver isNotNil ifFalse: nil ifTrue: `@arg' with: '`@receiver ifNotNil: `@arg';
+		
 		replace: '`@receiver isNil ifTrue: `@arg' with: '`@receiver ifNil: `@arg';
 		replace: '`@receiver isNil ifFalse: `@arg' with: '`@receiver ifNotNil: `@arg';
 		replace: '`@receiver isNotNil ifTrue: `@arg' with: '`@receiver ifNotNil: `@arg';


### PR DESCRIPTION
Improve nil condition cleaner to have even more rewrites:

		replace: '`@receiver isNil ifTrue: [ nil ] ifFalse: `@arg' with: '`@receiver ifNotNil: `@arg';
		replace: '`@receiver isNil ifTrue: nil ifFalse: `@arg' with: '`@receiver ifNotNil: `@arg';
		replace: '`@receiver isNil ifFalse: `@arg ifTrue: [ nil ]' with: '`@receiver ifNotNil: `@arg';
		replace: '`@receiver isNil ifFalse: `@arg ifTrue: nil' with: '`@receiver ifNotNil: `@arg';
		
		replace: '`@receiver isNotNil ifTrue: `@arg ifFalse: [ nil ]' with: '`@receiver ifNotNil: `@arg';
		replace: '`@receiver isNotNil ifTrue: `@arg ifFalse: nil' with: '`@receiver ifNotNil: `@arg';
		replace: '`@receiver isNotNil ifFalse: [ nil ] ifTrue: `@arg ' with: '`@receiver ifNotNil: `@arg';
		replace: '`@receiver isNotNil ifFalse: nil ifTrue: `@arg' with: '`@receiver ifNotNil: `@arg';

Fixes #63