### PR TITLE
96-Reapply-ChanelExtractReturnFromAllBranchesCleanerTest-on-methods-who-were-cleaned

### DIFF
--- a/src/Chanel-Tests/ChanelExtractReturnFromAllBranchesCleanerTest.class.st
+++ b/src/Chanel-Tests/ChanelExtractReturnFromAllBranchesCleanerTest.class.st
@@ -137,6 +137,17 @@ ChanelExtractReturnFromAllBranchesCleanerTest >> testDoesNotExtractReturnIfRetur
 ]
 
 { #category : #tests }
+ChanelExtractReturnFromAllBranchesCleanerTest >> testExtractReturnDoesNotFailForConditonsInConditions [
+	class compile: 'method
+	self toto1 ifTrue: [ self toto2 ifTrue: [ ^ 1 ] ifFalse: [ ^ 2 ] ] ifFalse: [ 3 ]'.
+
+	self runCleaner.
+	
+	self assert: (class >> #method) sourceCode equals: 'method
+  self toto1 ifTrue: [ ^self toto2 ifTrue: [ 1 ] ifFalse: [ 2 ] ] ifFalse: [ 3 ]'
+]
+
+{ #category : #tests }
 ChanelExtractReturnFromAllBranchesCleanerTest >> testExtractReturnDoesNotFailIfThereIsAlreadyAReturn [
 	class compile: 'method
   ^self toto ifTrue: [ ^ 1 ] ifFalse: [ ^ 2 ]'.
@@ -247,6 +258,17 @@ ChanelExtractReturnFromAllBranchesCleanerTest >> testExtractReturnIfTheLastState
 	self assert: (class >> #method) sourceCode equals: 'method
   self foo ifTrue: [ ^self toto ifTrue: [ 1 ] ifFalse: [ 2 ] ].
   self bar'
+]
+
+{ #category : #tests }
+ChanelExtractReturnFromAllBranchesCleanerTest >> testExtractReturnInNestedConditions [
+	class compile: 'method
+	self toto1 ifTrue: [ self toto2 ifTrue: [ ^1 ] ifFalse: [ ^2 ] ] ifFalse: [ ^3 ]'.
+
+	self runCleaner.
+	
+	self assert: (class >> #method) sourceCode equals: 'method
+  ^self toto1 ifTrue: [ self toto2 ifTrue: [ 1 ] ifFalse: [ 2 ] ] ifFalse: [ 3 ]'
 ]
 
 { #category : #tests }

--- a/src/Chanel/ChanelExtractReturnFromAllBranchesCleaner.class.st
+++ b/src/Chanel/ChanelExtractReturnFromAllBranchesCleaner.class.st
@@ -17,8 +17,14 @@ ChanelExtractReturnFromAllBranchesCleaner class >> priority [
 
 { #category : #cleaning }
 ChanelExtractReturnFromAllBranchesCleaner >> clean [
-	(self configuration localMethods iterator
-		| #ast collectIt
+  (self cleanASTs: (self configuration localMethods collect: #ast)) do: #install
+]
+
+{ #category : #cleaning }
+ChanelExtractReturnFromAllBranchesCleaner >> cleanASTs: aCollectionOfMethods [
+	"In the end we run again the cleaning on ASTs because we can have case of nested conditionals each of the having returns in their branches."
+
+	^ (aCollectionOfMethods iterator
 		| #allChildren flatCollectIt
 		| #isMessage selectIt
 		| #isCascaded rejectIt
@@ -29,5 +35,5 @@ ChanelExtractReturnFromAllBranchesCleaner >> clean [
 		| [ :node | node arguments do: #inlineLastReturn ] doIt
 		| #wrapsInReturn doIt
 		| #methodNode collectIt
-		> Set) do: #install
+		> Set) ifNotEmpty: [ :updatedASTs | self cleanASTs: updatedASTs. updatedASTs ]
 ]

--- a/src/Chanel/ChanelExtractReturnFromAllBranchesCleaner.class.st
+++ b/src/Chanel/ChanelExtractReturnFromAllBranchesCleaner.class.st
@@ -31,7 +31,7 @@ ChanelExtractReturnFromAllBranchesCleaner >> cleanASTs: aCollectionOfMethods [
 		| [ :node | node parent isLast: node ] selectIt
 		| #isConditionNecessarilyExecutingABranch selectIt
 		| [ :node | node arguments allSatisfy: #isBlock ] selectIt
-		| [ :node | node arguments allSatisfy: #hasBlockReturn ] selectIt
+		| [ :node | node arguments allSatisfy: #lastStatementIsReturn ] selectIt
 		| [ :node | node arguments do: #inlineLastReturn ] doIt
 		| #wrapsInReturn doIt
 		| #methodNode collectIt

--- a/src/Chanel/RBBlockNode.extension.st
+++ b/src/Chanel/RBBlockNode.extension.st
@@ -4,3 +4,8 @@ Extension { #name : #RBBlockNode }
 RBBlockNode >> inlineLastReturn [
 	self statements last inline
 ]
+
+{ #category : #'*Chanel' }
+RBBlockNode >> lastStatementIsReturn [
+	^ self statements last isReturn
+]


### PR DESCRIPTION
Improve extract return from conditionals cleaner.

Before it bugged when a conditional with returns was in a conditional with returns.

Fixes #96