### PR TITLE
99-Review-priority-system-to-use-topological-sort

### DIFF
--- a/src/Chanel-Tests/ChanelAbstractCleanerTest.class.st
+++ b/src/Chanel-Tests/ChanelAbstractCleanerTest.class.st
@@ -12,7 +12,7 @@ List of special cases to take into account when writing a new cleaner (add tests
 "
 Class {
 	#name : #ChanelAbstractCleanerTest,
-	#superclass : #TestCase,
+	#superclass : #ChanelAbstractTest,
 	#instVars : [
 		'previousFormater',
 		'package',
@@ -25,11 +25,6 @@ Class {
 { #category : #testing }
 ChanelAbstractCleanerTest class >> isAbstract [
 	^ self = ChanelAbstractCleanerTest
-]
-
-{ #category : #testing }
-ChanelAbstractCleanerTest class >> shouldInheritSelectors [
-	^ true
 ]
 
 { #category : #accessing }
@@ -95,11 +90,6 @@ ChanelAbstractCleanerTest >> extensionProtocol [
 ChanelAbstractCleanerTest >> methodBodyFor: aString [
 	^ '{1}
   {2}' format: {self selector . aString}
-]
-
-{ #category : #running }
-ChanelAbstractCleanerTest >> runCase [
-	EpMonitor disableDuring: [ super runCase ]
 ]
 
 { #category : #running }

--- a/src/Chanel-Tests/ChanelAbstractTest.class.st
+++ b/src/Chanel-Tests/ChanelAbstractTest.class.st
@@ -1,0 +1,20 @@
+Class {
+	#name : #ChanelAbstractTest,
+	#superclass : #TestCase,
+	#category : #'Chanel-Tests'
+}
+
+{ #category : #testing }
+ChanelAbstractTest class >> isAbstract [
+	^ self = ChanelAbstractTest
+]
+
+{ #category : #testing }
+ChanelAbstractTest class >> shouldInheritSelectors [
+	^ true
+]
+
+{ #category : #running }
+ChanelAbstractTest >> runCase [
+	EpMonitor disableDuring: [ super runCase ]
+]

--- a/src/Chanel-Tests/ChanelCleanersOrderTest.class.st
+++ b/src/Chanel-Tests/ChanelCleanersOrderTest.class.st
@@ -20,6 +20,16 @@ ChanelCleanersOrderTest >> setUp [
 ]
 
 { #category : #tests }
+ChanelCleanersOrderTest >> testAliasAndExtractReturnBeforeNilConditionalsBeforeCutConditionalBranches [
+	self
+		assert: 'self patate notNil ifFalse: [ ^ nil ] ifTrue: [ ^ 3 ].'
+		isRewrittenAs: '^self patate ifNotNil: [ 3 ]'
+		using:
+			{ChanelExtractReturnFromAllBranchesCleaner . ChanelNilConditionalSimplifierCleaner . ChanelCutConditionalBranchesCleaner.
+			ChanelMethodAliasesCleaner}
+]
+
+{ #category : #tests }
 ChanelCleanersOrderTest >> testAliasBeforeEmptyAssertions [
 	"The alias cleaner needs to run before the empty assertions cleaner."
 
@@ -33,16 +43,6 @@ ChanelCleanersOrderTest >> testAliasBeforeEmptyConditionals [
 	"The alias cleaner needs to run before the empty conditionals cleaner."
 
 	self assert: '#() notEmpty ifTrue: [ 1 ]' isRewrittenAs: '#() ifNotEmpty: [ 1 ]' using: {ChanelEmptyConditionalSimplifierCleaner . ChanelMethodAliasesCleaner}
-]
-
-{ #category : #tests }
-ChanelCleanersOrderTest >> testAliasBeforeExtractReturnBeforeNilConditionalsBeforeCutConditionalBranches [
-	self
-		assert: 'self patate notNil ifFalse: [ ^ nil ] ifTrue: [ ^ 3 ].'
-		isRewrittenAs: '^self patate ifNotNil: [ 3 ]'
-		using:
-			{ChanelExtractReturnFromAllBranchesCleaner . ChanelNilConditionalSimplifierCleaner . ChanelCutConditionalBranchesCleaner.
-			ChanelMethodAliasesCleaner}
 ]
 
 { #category : #tests }
@@ -83,6 +83,11 @@ ChanelCleanersOrderTest >> testAliasBeforeNilConditionalsBeforeCutConditionalBra
 ]
 
 { #category : #tests }
+ChanelCleanersOrderTest >> testAliasBeforeNilConditionalsBeforeCutConditionalsBeforeRemoveUselessAsignment [
+	self assert: 'test := test notNil ifTrue: [ test ]' isRewrittenAs: '' using: { ChanelCutConditionalBranchesCleaner . ChanelMethodAliasesCleaner . ChanelNilConditionalSimplifierCleaner . ChanelRemoveAssigmentWithoutEffectCleaner }
+]
+
+{ #category : #tests }
 ChanelCleanersOrderTest >> testAliasBeforeUnecessaryNot [
 	self assert: 'self toto notEmpty not' isRewrittenAs: 'self toto isEmpty' using: {ChanelRemoveUnecesaryNotCleaner . ChanelMethodAliasesCleaner}
 ]
@@ -101,6 +106,11 @@ ChanelCleanersOrderTest >> testAliasBeforeUnecessaryNotBeforeEmptySimplifier [
 { #category : #tests }
 ChanelCleanersOrderTest >> testAliasBeforeUnecessaryNotBeforeNilSimplifier [
 	self assert: 'self toto notNil not ifTrue: [ 1 ]' isRewrittenAs: 'self toto ifNil: [ 1 ]' using: {ChanelRemoveUnecesaryNotCleaner . ChanelMethodAliasesCleaner . ChanelNilConditionalSimplifierCleaner}
+]
+
+{ #category : #tests }
+ChanelCleanersOrderTest >> testCutConditionalsBeforeRemoveUselessAssignment [
+	self assert: 'test := test ifNotNil: [ test ]' isRewrittenAs: '' using: { ChanelCutConditionalBranchesCleaner . ChanelRemoveAssigmentWithoutEffectCleaner }
 ]
 
 { #category : #tests }
@@ -123,6 +133,12 @@ ChanelCleanersOrderTest >> testNilEqualityBeforeNilConditionalsBeforeCutConditio
 	"The nil equality cleaner needs to run before the nil conditionals cleaner which need to run before the cut conditional branches."
 
 	self assert: '(10 ~= nil) ifFalse: [ nil ]' isRewrittenAs: '10' using: {ChanelNilConditionalSimplifierCleaner . ChanelCutConditionalBranchesCleaner . ChanelNilEqualitySimplifierCleaner}
+]
+
+{ #category : #tests }
+ChanelCleanersOrderTest >> testUnecessaryNotBeforeTestEquality [
+	class := self createDefaultTestClass.
+	self assert: 'self assert: x equals: true not' isRewrittenAs: 'self deny: x' using: {ChanelRemoveUnecesaryNotCleaner . ChanelTestEqualityCleaner }
 ]
 
 { #category : #tests }

--- a/src/Chanel-Tests/ChanelTest.class.st
+++ b/src/Chanel-Tests/ChanelTest.class.st
@@ -3,7 +3,7 @@ A ChanelTest is a test class for testing the behavior of Chanel
 "
 Class {
 	#name : #ChanelTest,
-	#superclass : #TestCase,
+	#superclass : #ChanelAbstractTest,
 	#category : #'Chanel-Tests'
 }
 

--- a/src/Chanel/Chanel.class.st
+++ b/src/Chanel/Chanel.class.st
@@ -138,7 +138,13 @@ Chanel class >> worldMenuOn: aBuilder [
 
 { #category : #cleaning }
 Chanel >> cleanUsing: cleaners [
-	self cleanWithSelectedCleaners: ((cleaners select: [ :each | each isAvailableForPharo: self minimalPharoVersion ]) sort: #priority ascending)
+	| availableCleaners sortResult |
+	"Use topological sort to sort the cleaners to get the best effect possible with this set of cleaners."
+	availableCleaners := cleaners select: [ :each | each isAvailableForPharo: self minimalPharoVersion ].
+
+	sortResult := (MalTopologicalSorting nodes: availableCleaners incomingEdgesProperty: #requirements) run.
+
+	self cleanWithSelectedCleaners: (sortResult collect: #model)
 ]
 
 { #category : #cleaning }

--- a/src/Chanel/ChanelAbstractCleaner.class.st
+++ b/src/Chanel/ChanelAbstractCleaner.class.st
@@ -54,8 +54,10 @@ ChanelAbstractCleaner class >> isAvailableForPharo: anInteger [
 ]
 
 { #category : #accessing }
-ChanelAbstractCleaner class >> priority [
-	^ self subclassResponsibility
+ChanelAbstractCleaner class >> requirements [
+	"Returns the list of cleaners that should run before this cleaner"
+
+	^ #()
 ]
 
 { #category : #cleaning }

--- a/src/Chanel/ChanelClassifyUnclassifiedMethodsCleaner.class.st
+++ b/src/Chanel/ChanelClassifyUnclassifiedMethodsCleaner.class.st
@@ -11,8 +11,8 @@ Class {
 }
 
 { #category : #accessing }
-ChanelClassifyUnclassifiedMethodsCleaner class >> priority [
-	^ 10000
+ChanelClassifyUnclassifiedMethodsCleaner class >> requirements [
+	^ { ChanelProtocolsCleaner }
 ]
 
 { #category : #cleaning }

--- a/src/Chanel/ChanelCutConditionalBranchesCleaner.class.st
+++ b/src/Chanel/ChanelCutConditionalBranchesCleaner.class.st
@@ -11,8 +11,8 @@ Class {
 }
 
 { #category : #accessing }
-ChanelCutConditionalBranchesCleaner class >> priority [
-	^ 4000
+ChanelCutConditionalBranchesCleaner class >> requirements [
+	^ { ChanelExtractReturnFromAllBranchesCleaner . ChanelNilConditionalSimplifierCleaner . ChanelEmptyConditionalSimplifierCleaner }
 ]
 
 { #category : #cleaning }

--- a/src/Chanel/ChanelDuplicatedMethodFromTraitCleaner.class.st
+++ b/src/Chanel/ChanelDuplicatedMethodFromTraitCleaner.class.st
@@ -10,11 +10,6 @@ Class {
 	#category : #Chanel
 }
 
-{ #category : #accessing }
-ChanelDuplicatedMethodFromTraitCleaner class >> priority [
-	^ 100
-]
-
 { #category : #cleaning }
 ChanelDuplicatedMethodFromTraitCleaner >> clean [
 	self configuration definedClasses iterator

--- a/src/Chanel/ChanelEmptyConditionalSimplifierCleaner.class.st
+++ b/src/Chanel/ChanelEmptyConditionalSimplifierCleaner.class.st
@@ -11,8 +11,8 @@ Class {
 }
 
 { #category : #accessing }
-ChanelEmptyConditionalSimplifierCleaner class >> priority [
-	^ 3500
+ChanelEmptyConditionalSimplifierCleaner class >> requirements [
+	^ { ChanelMethodAliasesCleaner . ChanelRemoveUnecesaryNotCleaner }
 ]
 
 { #category : #cleaning }

--- a/src/Chanel/ChanelEnsureSuperIsCalledCleaner.class.st
+++ b/src/Chanel/ChanelEnsureSuperIsCalledCleaner.class.st
@@ -14,11 +14,6 @@ Class {
 	#category : #Chanel
 }
 
-{ #category : #accessing }
-ChanelEnsureSuperIsCalledCleaner class >> priority [
-	^ 5000
-]
-
 { #category : #cleaning }
 ChanelEnsureSuperIsCalledCleaner >> clean [
 	self configuration localMethods

--- a/src/Chanel/ChanelExtractReturnFromAllBranchesCleaner.class.st
+++ b/src/Chanel/ChanelExtractReturnFromAllBranchesCleaner.class.st
@@ -10,11 +10,6 @@ Class {
 	#category : #Chanel
 }
 
-{ #category : #accessing }
-ChanelExtractReturnFromAllBranchesCleaner class >> priority [
-	^ 3500
-]
-
 { #category : #cleaning }
 ChanelExtractReturnFromAllBranchesCleaner >> clean [
   (self cleanASTs: (self configuration localMethods collect: #ast)) do: #install

--- a/src/Chanel/ChanelMethodAliasesCleaner.class.st
+++ b/src/Chanel/ChanelMethodAliasesCleaner.class.st
@@ -14,13 +14,6 @@ Class {
 	#category : #Chanel
 }
 
-{ #category : #accessing }
-ChanelMethodAliasesCleaner class >> priority [
-	"I need to be high in the priority since I'll simplify next cleaners."
-
-	^ 500
-]
-
 { #category : #cleaning }
 ChanelMethodAliasesCleaner >> rewriter [
 	^ RBParseTreeRewriter new

--- a/src/Chanel/ChanelMethodsOnlyCallingSuperCleaner.class.st
+++ b/src/Chanel/ChanelMethodsOnlyCallingSuperCleaner.class.st
@@ -11,8 +11,8 @@ Class {
 }
 
 { #category : #accessing }
-ChanelMethodsOnlyCallingSuperCleaner class >> priority [
-	^ 8000
+ChanelMethodsOnlyCallingSuperCleaner class >> requirements [
+	^ { ChanelRemoveUnusedNodesFromASTCleaner. ChanelNilAssignationInInitializeCleaner . ChanelRemoveAssigmentWithoutEffectCleaner }
 ]
 
 { #category : #cleaning }

--- a/src/Chanel/ChanelNilAssignationInInitializeCleaner.class.st
+++ b/src/Chanel/ChanelNilAssignationInInitializeCleaner.class.st
@@ -11,11 +11,6 @@ Class {
 	#category : #Chanel
 }
 
-{ #category : #accessing }
-ChanelNilAssignationInInitializeCleaner class >> priority [
-	^ 6000
-]
-
 { #category : #cleaning }
 ChanelNilAssignationInInitializeCleaner >> clean [
 	self configuration localMethods iterator

--- a/src/Chanel/ChanelNilConditionalSimplifierCleaner.class.st
+++ b/src/Chanel/ChanelNilConditionalSimplifierCleaner.class.st
@@ -28,8 +28,8 @@ Class {
 }
 
 { #category : #accessing }
-ChanelNilConditionalSimplifierCleaner class >> priority [
-	^ 3000
+ChanelNilConditionalSimplifierCleaner class >> requirements [
+	^ { ChanelMethodAliasesCleaner . ChanelRemoveUnecesaryNotCleaner . ChanelNilEqualitySimplifierCleaner }
 ]
 
 { #category : #cleaning }

--- a/src/Chanel/ChanelNilEqualitySimplifierCleaner.class.st
+++ b/src/Chanel/ChanelNilEqualitySimplifierCleaner.class.st
@@ -11,8 +11,8 @@ Class {
 }
 
 { #category : #accessing }
-ChanelNilEqualitySimplifierCleaner class >> priority [
-	^ 2500
+ChanelNilEqualitySimplifierCleaner class >> requirements [
+	^ { ChanelMethodAliasesCleaner }
 ]
 
 { #category : #cleaning }

--- a/src/Chanel/ChanelProtocolsCleaner.class.st
+++ b/src/Chanel/ChanelProtocolsCleaner.class.st
@@ -47,11 +47,6 @@ ChanelProtocolsCleaner class >> methodsInSpecificProtocolMap [
 ]
 
 { #category : #accessing }
-ChanelProtocolsCleaner class >> priority [
-	^ 2000
-]
-
-{ #category : #accessing }
 ChanelProtocolsCleaner class >> protocolsToCleanMap [
 	^ ProtocolsToCleanMap
 		ifNil: [ ProtocolsToCleanMap := Dictionary new

--- a/src/Chanel/ChanelRemoveAssigmentWithoutEffectCleaner.class.st
+++ b/src/Chanel/ChanelRemoveAssigmentWithoutEffectCleaner.class.st
@@ -11,8 +11,8 @@ Class {
 }
 
 { #category : #accessing }
-ChanelRemoveAssigmentWithoutEffectCleaner class >> priority [
-	^ 300
+ChanelRemoveAssigmentWithoutEffectCleaner class >> requirements [
+	^ { ChanelCutConditionalBranchesCleaner }
 ]
 
 { #category : #cleaning }

--- a/src/Chanel/ChanelRemoveMethodsWithEquivalentInSuperClassCleaner.class.st
+++ b/src/Chanel/ChanelRemoveMethodsWithEquivalentInSuperClassCleaner.class.st
@@ -11,8 +11,8 @@ Class {
 }
 
 { #category : #accessing }
-ChanelRemoveMethodsWithEquivalentInSuperClassCleaner class >> priority [
-	^ 1500
+ChanelRemoveMethodsWithEquivalentInSuperClassCleaner class >> requirements [
+	^ { ChanelRemoveUnusedNodesFromASTCleaner . ChanelNilAssignationInInitializeCleaner . ChanelRemoveAssigmentWithoutEffectCleaner }
 ]
 
 { #category : #cleaning }

--- a/src/Chanel/ChanelRemoveUnecesaryNotCleaner.class.st
+++ b/src/Chanel/ChanelRemoveUnecesaryNotCleaner.class.st
@@ -11,8 +11,8 @@ Class {
 }
 
 { #category : #accessing }
-ChanelRemoveUnecesaryNotCleaner class >> priority [
-	^ 1200
+ChanelRemoveUnecesaryNotCleaner class >> requirements [
+	^ { ChanelMethodAliasesCleaner }
 ]
 
 { #category : #cleaning }

--- a/src/Chanel/ChanelRemoveUnusedNodesFromASTCleaner.class.st
+++ b/src/Chanel/ChanelRemoveUnusedNodesFromASTCleaner.class.st
@@ -11,8 +11,8 @@ Class {
 }
 
 { #category : #accessing }
-ChanelRemoveUnusedNodesFromASTCleaner class >> priority [
-	^ 7500
+ChanelRemoveUnusedNodesFromASTCleaner class >> requirements [
+	^ { ChanelUnreadTemporaryCleaner }
 ]
 
 { #category : #cleaning }

--- a/src/Chanel/ChanelTestCaseNameCleaner.class.st
+++ b/src/Chanel/ChanelTestCaseNameCleaner.class.st
@@ -10,11 +10,6 @@ Class {
 	#category : #Chanel
 }
 
-{ #category : #accessing }
-ChanelTestCaseNameCleaner class >> priority [
-	^ 4500
-]
-
 { #category : #cleaning }
 ChanelTestCaseNameCleaner >> clean [
 	self configuration definedTestCases iterator

--- a/src/Chanel/ChanelTestEmptyAssertionsCleaner.class.st
+++ b/src/Chanel/ChanelTestEmptyAssertionsCleaner.class.st
@@ -18,8 +18,8 @@ ChanelTestEmptyAssertionsCleaner class >> isAvailableForPharo: anInteger [
 ]
 
 { #category : #accessing }
-ChanelTestEmptyAssertionsCleaner class >> priority [
-	^ 1300
+ChanelTestEmptyAssertionsCleaner class >> requirements [
+	^ { ChanelMethodAliasesCleaner . ChanelRemoveUnecesaryNotCleaner }
 ]
 
 { #category : #cleaning }

--- a/src/Chanel/ChanelTestEqualityCleaner.class.st
+++ b/src/Chanel/ChanelTestEqualityCleaner.class.st
@@ -37,8 +37,8 @@ Class {
 }
 
 { #category : #accessing }
-ChanelTestEqualityCleaner class >> priority [
-	^ 1000
+ChanelTestEqualityCleaner class >> requirements [
+	^ { ChanelRemoveUnecesaryNotCleaner }
 ]
 
 { #category : #cleaning }

--- a/src/Chanel/ChanelUnreadTemporaryCleaner.class.st
+++ b/src/Chanel/ChanelUnreadTemporaryCleaner.class.st
@@ -11,8 +11,8 @@ Class {
 }
 
 { #category : #accessing }
-ChanelUnreadTemporaryCleaner class >> priority [
-	^ 7000
+ChanelUnreadTemporaryCleaner class >> requirements [
+	^ { ChanelCutConditionalBranchesCleaner . ChanelNilAssignationInInitializeCleaner . ChanelRemoveAssigmentWithoutEffectCleaner }
 ]
 
 { #category : #cleaning }

--- a/src/Chanel/MalGraphAlgorithm.extension.st
+++ b/src/Chanel/MalGraphAlgorithm.extension.st
@@ -1,0 +1,14 @@
+Extension { #name : #MalGraphAlgorithm }
+
+{ #category : #'*Chanel' }
+MalGraphAlgorithm >> addIncomingEdgesFollowing: aBlock [
+	self edges: (nodes flatCollect: [ :node | (aBlock value: node model) collect: [ :each | node model -> each ] ]) from: #key to: #value
+]
+
+{ #category : #'*Chanel' }
+MalGraphAlgorithm class >> nodes: aCollection incomingEdgesProperty: aValuable [
+	^ self new
+		nodes: aCollection;
+		addIncomingEdgesFollowing: aValuable;
+		yourself
+]


### PR DESCRIPTION
Use topological sorting to sort cleaners.

Also add new tests to ensure cleaners are run in the right order.

Fixes #99