### PR TITLE
93-Remove-nil-assignment-can-fail-in-case-of-assignment-in-an-assignment

### DIFF
--- a/src/Chanel-Tests/ChanelNilAssignationInInitializeCleanerTest.class.st
+++ b/src/Chanel-Tests/ChanelNilAssignationInInitializeCleanerTest.class.st
@@ -144,3 +144,20 @@ ChanelNilAssignationInInitializeCleanerTest >> testRemoveNilAssigmentsAroundReal
   super initialize.
   notTest := 1'
 ]
+
+{ #category : #tests }
+ChanelNilAssignationInInitializeCleanerTest >> testRemoveNilChainedAssigments [
+	class
+		compile:
+			'initialize
+  super initialize.
+  test := test2 := test3 := test4 := nil'.
+
+	self runCleaner.
+
+	self
+		assert: (class >> #initialize) sourceCode
+		equals:
+			'initialize
+  super initialize'
+]

--- a/src/Chanel/ChanelNilAssignationInInitializeCleaner.class.st
+++ b/src/Chanel/ChanelNilAssignationInInitializeCleaner.class.st
@@ -16,6 +16,6 @@ ChanelNilAssignationInInitializeCleaner >> clean [
 	self configuration localMethods iterator
 		| [ :method | method selector = #initialize ] selectIt
 		| [ :method | method ast nilAssignmentNodes isNotEmpty ] selectIt
-		| [ :method | method ast nilAssignmentNodes do: #removeFromTree ] doIt
+		| [ :method | method ast nilAssignmentNodes do: #removeAssignations ] doIt
 		> #installAST doIt
 ]

--- a/src/Chanel/RBAssignmentNode.extension.st
+++ b/src/Chanel/RBAssignmentNode.extension.st
@@ -4,3 +4,12 @@ Extension { #name : #RBAssignmentNode }
 RBAssignmentNode >> canHaveUselessChildren [
 	^ false
 ]
+
+{ #category : #'*Chanel' }
+RBAssignmentNode >> removeAssignations [
+	"In case the assignation is in an assignation, we want to remove the parent aswel."
+
+	self parent isAssignment
+		ifTrue: [ self parent removeAssignations ]
+		ifFalse: [ self removeFromTree ]
+]


### PR DESCRIPTION
Fix bug in remove nil assignation from initialize.

#removeFromTree does not work on assignations if the parent is anothen assignation. 
Update the code to remove the full chaine of assignations in that case + add a test. 

Fixes #93