### PR TITLE
91-Add-new-cases-to-not-cleaner

### DIFF
--- a/resources/doc/documentation.md
+++ b/resources/doc/documentation.md
@@ -543,6 +543,12 @@ Chanel remove some unecessary call to `not` to make code easier to read. Here is
 | `[ a not] whileFalse: y` | `[ a] whileTrue: y` |
 | `[ a not] whileTrue` | `[ a] whileFalse` |
 | `[ a not] whileFalse` | `[ a] whileTrue` |
+| `self assert: x not` | `self deny: x` |
+| `self deny: x not` | `self assert: x` |
+| `self assert: x equals: y not` | `self deny: x equals: y` |
+| `self assert: x not equals: y` | `self deny: x equals: y` |
+| `self deny: x equals: y not` | `self assert: x equals: y` |
+| `self deny: x not equals: y` | `self assert: x equals: y` |
 
 *Conditions for the cleanings to by applied:*
 - Can be applied on any classes and traits.

--- a/src/Chanel-Tests/ChanelRemoveUnecesaryNotCleanerTest.class.st
+++ b/src/Chanel-Tests/ChanelRemoveUnecesaryNotCleanerTest.class.st
@@ -24,6 +24,46 @@ ChanelRemoveUnecesaryNotCleanerTest >> setUp [
 ]
 
 { #category : #tests }
+ChanelRemoveUnecesaryNotCleanerTest >> testAssertEquals2NotNotReplacedForPharo6 [
+	self deny: 'self assert: self toto not equals: self tata' isRewrittenForPharo: 6
+]
+
+{ #category : #tests }
+ChanelRemoveUnecesaryNotCleanerTest >> testAssertEqualsNot [
+	self assert: 'self assert: self toto equals: self tata not' isRewrittenAs: 'self deny: self toto equals: self tata'
+]
+
+{ #category : #tests }
+ChanelRemoveUnecesaryNotCleanerTest >> testAssertEqualsNot2 [
+	self assert: 'self assert: self toto not equals: self tata' isRewrittenAs: 'self deny: self toto equals: self tata'
+]
+
+{ #category : #tests }
+ChanelRemoveUnecesaryNotCleanerTest >> testAssertEqualsNotNotReplacedForPharo6 [
+	self deny: 'self assert: self toto equals: self tata not' isRewrittenForPharo: 6
+]
+
+{ #category : #tests }
+ChanelRemoveUnecesaryNotCleanerTest >> testAssertNot [
+	self assert: 'self assert: self toto not' isRewrittenAs: 'self deny: self toto'
+]
+
+{ #category : #tests }
+ChanelRemoveUnecesaryNotCleanerTest >> testDenyEqualsNot [
+	self assert: 'self deny: self toto equals: self tata not' isRewrittenAs: 'self assert: self toto equals: self tata'
+]
+
+{ #category : #tests }
+ChanelRemoveUnecesaryNotCleanerTest >> testDenyEqualsNot2 [
+	self assert: 'self deny: self toto not equals: self tata' isRewrittenAs: 'self assert: self toto equals: self tata'
+]
+
+{ #category : #tests }
+ChanelRemoveUnecesaryNotCleanerTest >> testDenyNot [
+	self assert: 'self deny: self toto not' isRewrittenAs: 'self assert: self toto'
+]
+
+{ #category : #tests }
 ChanelRemoveUnecesaryNotCleanerTest >> testDifferent2Not [
 	self assert: '(self toto ~~ self tata) not' isRewrittenAs: 'self toto == self tata'
 ]

--- a/src/Chanel/ChanelRemoveUnecesaryNotCleaner.class.st
+++ b/src/Chanel/ChanelRemoveUnecesaryNotCleaner.class.st
@@ -49,6 +49,13 @@ ChanelRemoveUnecesaryNotCleaner >> rewriter [
 		replace: '[| `@temps | ``@.Statements. ``@object not] whileFalse: ``@block' with: '[| `@temps | ``@.Statements. ``@object] whileTrue: ``@block';
 		replace: '[| `@temps | ``@.Statements. ``@object not] whileTrue' with: '[| `@temps | ``@.Statements. ``@object] whileFalse';
 		replace: '[| `@temps | ``@.Statements. ``@object not] whileFalse' with: '[| `@temps | ``@.Statements. ``@object] whileTrue';
+		
+		replace: 'self assert: `@arg not' with: 'self deny: `@arg';
+		replace: 'self deny: `@arg not' with: 'self assert: `@arg';
+		replace: 'self assert: `@arg1 equals: `@arg2 not' with: 'self deny: `@arg1 equals: `@arg2' when: [ :n | self minimalPharoVersion >= 7 ];
+		replace: 'self assert: `@arg1 not equals: `@arg2' with: 'self deny: `@arg1 equals: `@arg2' when: [ :n | self minimalPharoVersion >= 7 ];
+		replace: 'self deny: `@arg1 equals: `@arg2 not' with: 'self assert: `@arg1 equals: `@arg2';
+		replace: 'self deny: `@arg1 not equals: `@arg2' with: 'self assert: `@arg1 equals: `@arg2';
 	
 		yourself
 ]


### PR DESCRIPTION
Simplify some assertions using not. 

Fixes #91


| `self assert: x not` | `self deny: x` |
| `self deny: x not` | `self assert: x` |
| `self assert: x equals: y not` | `self deny: x equals: y` |
| `self assert: x not equals: y` | `self deny: x equals: y` |
| `self deny: x equals: y not` | `self assert: x equals: y` |
| `self deny: x not equals: y` | `self assert: x equals: y` |