### PR TITLE
92-Add-a-cleaner-to-extract-an-assignation-happening-in-both-branches-as-last-statement

### DIFF
--- a/src/Chanel-Tests/ChanelAbstractCleanerTest.class.st
+++ b/src/Chanel-Tests/ChanelAbstractCleanerTest.class.st
@@ -33,6 +33,22 @@ ChanelAbstractCleanerTest >> actualClass [
 ]
 
 { #category : #helpers }
+ChanelAbstractCleanerTest >> assert: original isRewrittenAs: expected [
+	class ifNil: [ self error: 'To use this method you need to setup the class variable' ].
+
+	self assert: original isRewrittenAs: expected in: class
+]
+
+{ #category : #helpers }
+ChanelAbstractCleanerTest >> assert: original isRewrittenAs: expected in: aClass [
+	aClass compile: (self methodBodyFor: original).
+
+	self runCleaner.
+
+	self assert: (aClass >> self selector) sourceCode equals: (self methodBodyFor: expected)
+]
+
+{ #category : #helpers }
 ChanelAbstractCleanerTest >> createClassNamed: aSymbol [
 	^ self createSubclassOf: Object named: aSymbol
 ]
@@ -79,6 +95,21 @@ ChanelAbstractCleanerTest >> defaultClassName [
 { #category : #accessing }
 ChanelAbstractCleanerTest >> defaultTraitName [
 	^ ('T' , self defaultClassName) asSymbol
+]
+
+{ #category : #helpers }
+ChanelAbstractCleanerTest >> denyIsRewritten: aString [
+	| oldMethod |
+	class ifNil: [ self error: 'To use this method you need to setup the class variable' ].
+
+	class compile: (self methodBodyFor: aString).
+
+	oldMethod := class >> self selector.
+	self runCleaner.
+
+	self assert: (class >> self selector) sourceCode equals: (self methodBodyFor: aString).
+
+	self assert: class >> self selector identicalTo: oldMethod
 ]
 
 { #category : #running }

--- a/src/Chanel-Tests/ChanelCleanersOrderTest.class.st
+++ b/src/Chanel-Tests/ChanelCleanersOrderTest.class.st
@@ -20,6 +20,16 @@ ChanelCleanersOrderTest >> setUp [
 ]
 
 { #category : #tests }
+ChanelCleanersOrderTest >> testAliasAndExtractAssignationBeforeNilConditionalsBeforeCutConditionalBranches [
+	self
+		assert: 'self patate notNil ifFalse: [ test := nil ] ifTrue: [ test := 3 ].'
+		isRewrittenAs: 'test := self patate ifNotNil: [ 3 ]'
+		using:
+			{ChanelExtractAssignationsFromConditionals . ChanelNilConditionalSimplifierCleaner . ChanelCutConditionalBranchesCleaner.
+			ChanelMethodAliasesCleaner}
+]
+
+{ #category : #tests }
 ChanelCleanersOrderTest >> testAliasAndExtractReturnBeforeNilConditionalsBeforeCutConditionalBranches [
 	self
 		assert: 'self patate notNil ifFalse: [ ^ nil ] ifTrue: [ ^ 3 ].'
@@ -119,6 +129,14 @@ ChanelCleanersOrderTest >> testExtractReturnBeforeCutConditionals [
 		assert: 'self toto ifNil: [ ^ 1 ] ifNotNil: [ :e | ^ e ]'
 		isRewrittenAs: '^self toto ifNil: [ 1 ]'
 		using: {ChanelCutConditionalBranchesCleaner . ChanelExtractReturnFromAllBranchesCleaner}
+]
+
+{ #category : #tests }
+ChanelCleanersOrderTest >> testExtractassignationBeforeCutConditionals [
+	self
+		assert: 'self toto ifNil: [ test := 1 ] ifNotNil: [ :e | test := e ]'
+		isRewrittenAs: 'test := self toto ifNil: [ 1 ]'
+		using: {ChanelCutConditionalBranchesCleaner . ChanelExtractAssignationsFromConditionals}
 ]
 
 { #category : #tests }

--- a/src/Chanel-Tests/ChanelExtractAssignationsFromConditionalsTest.class.st
+++ b/src/Chanel-Tests/ChanelExtractAssignationsFromConditionalsTest.class.st
@@ -14,12 +14,137 @@ ChanelExtractAssignationsFromConditionalsTest >> setUp [
 ]
 
 { #category : #tests }
+ChanelExtractAssignationsFromConditionalsTest >> testDoesNotExtractAssignationIfABranchIsASymbol [
+	self denyIsRewritten: 'self toto ifNil: [ test := 1 ] ifNotNil: #yourself'
+]
+
+{ #category : #tests }
+ChanelExtractAssignationsFromConditionalsTest >> testDoesNotExtractAssignationIfAlreadyOutside [
+	self denyIsRewritten: 'test := self toto ifTrue: [ 1 ] ifFalse: [ 2 ]'
+]
+
+{ #category : #tests }
+ChanelExtractAssignationsFromConditionalsTest >> testDoesNotExtractAssignationIfAssignationIsNotTheLastStatement [
+	self denyIsRewritten: 'self toto ifTrue: [ test := 1 ] ifFalse: [ self foo ifTrue: [ test := 2 ] ]'
+]
+
+{ #category : #tests }
+ChanelExtractAssignationsFromConditionalsTest >> testDoesNotExtractAssignationIfInACascade [
+	self denyIsRewritten: 'self toto ifTrue: [ test := 1 ] ifFalse: [ test := 2 ]; bar'
+]
+
+{ #category : #tests }
+ChanelExtractAssignationsFromConditionalsTest >> testDoesNotExtractAssignationIfOnBranchDoesNotHaveOne [
+	self denyIsRewritten: 'self toto ifTrue: [ test := 1 ] ifFalse: [ 2 ]'
+]
+
+{ #category : #tests }
+ChanelExtractAssignationsFromConditionalsTest >> testExtractAssignationDoesNotFailForConditonsInConditions [
+	self
+		assert: 'self toto1 ifTrue: [ self toto2 ifTrue: [ test := 1 ] ifFalse: [ test := 2 ] ] ifFalse: [ 3 ]'
+		isRewrittenAs: 'self toto1 ifTrue: [ test := self toto2 ifTrue: [ 1 ] ifFalse: [ 2 ] ] ifFalse: [ 3 ]'
+]
+
+{ #category : #tests }
+ChanelExtractAssignationsFromConditionalsTest >> testExtractAssignationDoesNotFailIfThereIsAlreadyAAssignation [
+	self assert: 'test := self toto ifTrue: [ test := 1 ] ifFalse: [ test := 2 ]' isRewrittenAs: 'test := self toto ifTrue: [ 1 ] ifFalse: [ 2 ]'
+]
+
+{ #category : #tests }
+ChanelExtractAssignationsFromConditionalsTest >> testExtractAssignationEvenIfMessageIsNotTheLastStatement [
+	self
+		assert:
+			'self toto ifTrue: [ test := 1 ] ifFalse: [ test := 2 ].
+  self bar'
+		isRewrittenAs:
+			'test := self toto ifTrue: [ 1 ] ifFalse: [ 2 ].
+  self bar'
+]
+
+{ #category : #tests }
+ChanelExtractAssignationsFromConditionalsTest >> testExtractAssignationFromIfEmptyIfNotEmpty [
+	self assert: 'self toto ifEmpty: [ test := 2 ] ifNotEmpty: [ test := 1 ]' isRewrittenAs: 'test := self toto ifEmpty: [ 2 ] ifNotEmpty: [ 1 ]'
+]
+
+{ #category : #tests }
+ChanelExtractAssignationsFromConditionalsTest >> testExtractAssignationFromIfExistsIfAbsent [
+	self assert: 'self toto ifExists: [ test := 2 ] ifAbsent: [ test := 1 ]' isRewrittenAs: 'test := self toto ifExists: [ 2 ] ifAbsent: [ 1 ]'
+]
+
+{ #category : #tests }
+ChanelExtractAssignationsFromConditionalsTest >> testExtractAssignationFromIfFalseIfTrue [
+	self assert: 'self toto ifFalse: [ test := 2 ] ifTrue: [ test := 1 ]' isRewrittenAs: 'test := self toto ifFalse: [ 2 ] ifTrue: [ 1 ]'
+]
+
+{ #category : #tests }
+ChanelExtractAssignationsFromConditionalsTest >> testExtractAssignationFromIfNilIfNotNil [
+	self assert: 'self toto ifNil: [ test := 2 ] ifNotNil: [ test := 1 ]' isRewrittenAs: 'test := self toto ifNil: [ 2 ] ifNotNil: [ 1 ]'
+]
+
+{ #category : #tests }
+ChanelExtractAssignationsFromConditionalsTest >> testExtractAssignationFromIfNotEmptyIfEmpty [
+	self assert: 'self toto ifNotEmpty: [ test := 2 ] ifEmpty: [ test := 1 ]' isRewrittenAs: 'test := self toto ifNotEmpty: [ 2 ] ifEmpty: [ 1 ]'
+]
+
+{ #category : #tests }
+ChanelExtractAssignationsFromConditionalsTest >> testExtractAssignationFromIfNotNilIfNil [
+	self assert: 'self toto ifNotNil: [ test := 2 ] ifNil: [ test := 1 ]' isRewrittenAs: 'test := self toto ifNotNil: [ 2 ] ifNil: [ 1 ]'
+]
+
+{ #category : #tests }
 ChanelExtractAssignationsFromConditionalsTest >> testExtractAssignationFromIfTrueIfFalse [
-	class compile: 'method
-  self toto ifTrue: [ test :=1 ] ifFalse: [ test := 2 ]'.
+	self assert: 'self toto ifTrue: [ test := 1 ] ifFalse: [ test := 2 ]' isRewrittenAs: 'test := self toto ifTrue: [ 1 ] ifFalse: [ 2 ]'
+]
+
+{ #category : #tests }
+ChanelExtractAssignationsFromConditionalsTest >> testExtractAssignationFromIfTrueIfFalseWithOtherStatements [
+	self assert: 'self toto ifTrue: [ self foo. test := 1 ] ifFalse: [ test := self bar ]' isRewrittenAs: 'test := self toto ifTrue: [ self foo.
+        1 ] ifFalse: [ self bar ]'
+]
+
+{ #category : #tests }
+ChanelExtractAssignationsFromConditionalsTest >> testExtractAssignationIfTheLastStatementOfABlock [
+	self
+		assert:
+			'self foo ifTrue: [ self toto ifTrue: [ test := 1 ] ifFalse: [ test := 2 ] ].
+  self bar'
+		isRewrittenAs:
+			'self foo ifTrue: [ test := self toto ifTrue: [ 1 ] ifFalse: [ 2 ] ].
+  self bar'
+]
+
+{ #category : #tests }
+ChanelExtractAssignationsFromConditionalsTest >> testExtractAssignationInNestedConditions [
+	self
+		assert: 'self toto1 ifTrue: [ self toto2 ifTrue: [ test := 1 ] ifFalse: [ test := 2 ] ] ifFalse: [ test := 3 ]'
+		isRewrittenAs: 'test := self toto1 ifTrue: [ self toto2 ifTrue: [ 1 ] ifFalse: [ 2 ] ] ifFalse: [ 3 ]'
+]
+
+{ #category : #tests }
+ChanelExtractAssignationsFromConditionalsTest >> testExtractAssignationInTrait [
+	| trait |
+	trait := self createDefaultTrait.
+
+	class setTraitComposition: trait.
+
+	trait
+		compile:
+			'method
+  self toto ifTrue: [ test := 1 ] ifFalse: [ test := 2 ]'.
 
 	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
-  test := self toto ifTrue: [ 1 ] ifFalse: [ 2 ]'
+
+	self
+		assert: (trait >> #method) sourceCode
+		equals:
+			'method
+  test := self toto ifTrue: [ 1 ] ifFalse: [ 2 ]'.
+
+	self assert: (trait localSelectors includes: #method).
+	self deny: (class localSelectors includes: #method)
+]
+
+{ #category : #tests }
+ChanelExtractAssignationsFromConditionalsTest >> testExtractAssignationOnClassSide [
+	self assert: 'self toto ifTrue: [ test := 1 ] ifFalse: [ test := 2 ]' isRewrittenAs: 'test := self toto ifTrue: [ 1 ] ifFalse: [ 2 ]' in: class class
 ]

--- a/src/Chanel-Tests/ChanelExtractAssignationsFromConditionalsTest.class.st
+++ b/src/Chanel-Tests/ChanelExtractAssignationsFromConditionalsTest.class.st
@@ -1,0 +1,25 @@
+"
+A ChanelExtractAssignationsFromConditionalsTest is a test class for testing the behavior of ChanelExtractAssignationsFromConditionals
+"
+Class {
+	#name : #ChanelExtractAssignationsFromConditionalsTest,
+	#superclass : #ChanelAbstractCleanerTest,
+	#category : #'Chanel-Tests'
+}
+
+{ #category : #running }
+ChanelExtractAssignationsFromConditionalsTest >> setUp [
+	super setUp.
+	class := self createDefaultClass
+]
+
+{ #category : #tests }
+ChanelExtractAssignationsFromConditionalsTest >> testExtractAssignationFromIfTrueIfFalse [
+	class compile: 'method
+  self toto ifTrue: [ test :=1 ] ifFalse: [ test := 2 ]'.
+
+	self runCleaner.
+	
+	self assert: (class >> #method) sourceCode equals: 'method
+  test := self toto ifTrue: [ 1 ] ifFalse: [ 2 ]'
+]

--- a/src/Chanel-Tests/ChanelExtractReturnFromAllBranchesCleanerTest.class.st
+++ b/src/Chanel-Tests/ChanelExtractReturnFromAllBranchesCleanerTest.class.st
@@ -15,260 +15,104 @@ ChanelExtractReturnFromAllBranchesCleanerTest >> setUp [
 
 { #category : #tests }
 ChanelExtractReturnFromAllBranchesCleanerTest >> testDoesNotExtractReturnIfABranchIsASymbol [
-	| oldMethod |
-	class
-		compile:
-			'method
-  self toto ifNil: [ ^ 1 ] ifNotNil: #yourself'.
-
-	oldMethod := class >> #method.
-
-	self runCleaner.
-
-	self
-		assert: (class >> #method) sourceCode
-		equals:
-			'method
-  self toto ifNil: [ ^ 1 ] ifNotNil: #yourself'.
-
-	self assert: oldMethod identicalTo: class >> #method
+	self denyIsRewritten: 'self toto ifNil: [ ^ 1 ] ifNotNil: #yourself'
 ]
 
 { #category : #tests }
 ChanelExtractReturnFromAllBranchesCleanerTest >> testDoesNotExtractReturnIfAlreadyOutside [
-	| oldMethod |
-	class
-		compile:
-			'method
-  ^ self toto ifTrue: [ 1 ] ifFalse: [ 2 ]'.
-
-	oldMethod := class >> #method.
-
-	self runCleaner.
-
-	self
-		assert: (class >> #method) sourceCode
-		equals:
-			'method
-  ^ self toto ifTrue: [ 1 ] ifFalse: [ 2 ]'.
-
-	self assert: oldMethod identicalTo: class >> #method
+	self denyIsRewritten: '^ self toto ifTrue: [ 1 ] ifFalse: [ 2 ]'
 ]
 
 { #category : #tests }
 ChanelExtractReturnFromAllBranchesCleanerTest >> testDoesNotExtractReturnIfInACascade [
-	| oldMethod |
-	class compile: 'method
-  self toto ifTrue: [ ^ 1 ] ifFalse: [ ^ 2 ]; bar'.
-
-	oldMethod := class >> #method.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
-  self toto ifTrue: [ ^ 1 ] ifFalse: [ ^ 2 ]; bar'.
-
-	self assert: oldMethod identicalTo: class >> #method
+	self denyIsRewritten: 'self toto ifTrue: [ ^ 1 ] ifFalse: [ ^ 2 ]; bar'
 ]
 
 { #category : #tests }
 ChanelExtractReturnFromAllBranchesCleanerTest >> testDoesNotExtractReturnIfMessageIsNotTheLastStatement [
-	| oldMethod |
-	class
-		compile:
-			'method
-  self toto ifTrue: [ ^ 1 ] ifFalse: [ ^ 2 ].
-  self bar'.
-
-	oldMethod := class >> #method.
-
-	self runCleaner.
-
-	self
-		assert: (class >> #method) sourceCode
-		equals:
-			'method
-  self toto ifTrue: [ ^ 1 ] ifFalse: [ ^ 2 ].
-  self bar'.
-
-	self assert: oldMethod identicalTo: class >> #method
+	self denyIsRewritten: 'self toto ifTrue: [ ^ 1 ] ifFalse: [ ^ 2 ].
+  self bar'
 ]
 
 { #category : #tests }
 ChanelExtractReturnFromAllBranchesCleanerTest >> testDoesNotExtractReturnIfOnBranchDoesNotHaveOne [
-	| oldMethod |
-	class
-		compile:
-			'method
-  self toto ifTrue: [ ^ 1 ] ifFalse: [ 2 ]'.
-
-	oldMethod := class >> #method.
-
-	self runCleaner.
-
-	self
-		assert: (class >> #method) sourceCode
-		equals:
-			'method
-  self toto ifTrue: [ ^ 1 ] ifFalse: [ 2 ]'.
-
-	self assert: oldMethod identicalTo: class >> #method
+	self denyIsRewritten: 'self toto ifTrue: [ ^ 1 ] ifFalse: [ 2 ]'
 ]
 
 { #category : #tests }
 ChanelExtractReturnFromAllBranchesCleanerTest >> testDoesNotExtractReturnIfReturnIsNotTheLastStatement [
-	| oldMethod |
-	class
-		compile:
-			'method
-  self toto ifTrue: [ ^ 1 ] ifFalse: [ self foo ifTrue: [ ^ 2 ] ]'.
-
-	oldMethod := class >> #method.
-
-	self runCleaner.
-
-	self
-		assert: (class >> #method) sourceCode
-		equals:
-			'method
-  self toto ifTrue: [ ^ 1 ] ifFalse: [ self foo ifTrue: [ ^ 2 ] ]'.
-
-	self assert: oldMethod identicalTo: class >> #method
+	self denyIsRewritten: 'self toto ifTrue: [ ^ 1 ] ifFalse: [ self foo ifTrue: [ ^ 2 ] ]'
 ]
 
 { #category : #tests }
 ChanelExtractReturnFromAllBranchesCleanerTest >> testExtractReturnDoesNotFailForConditonsInConditions [
-	class compile: 'method
-	self toto1 ifTrue: [ self toto2 ifTrue: [ ^ 1 ] ifFalse: [ ^ 2 ] ] ifFalse: [ 3 ]'.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
-  self toto1 ifTrue: [ ^self toto2 ifTrue: [ 1 ] ifFalse: [ 2 ] ] ifFalse: [ 3 ]'
+	self
+		assert: 'self toto1 ifTrue: [ self toto2 ifTrue: [ ^ 1 ] ifFalse: [ ^ 2 ] ] ifFalse: [ 3 ]'
+		isRewrittenAs: 'self toto1 ifTrue: [ ^self toto2 ifTrue: [ 1 ] ifFalse: [ 2 ] ] ifFalse: [ 3 ]'
 ]
 
 { #category : #tests }
 ChanelExtractReturnFromAllBranchesCleanerTest >> testExtractReturnDoesNotFailIfThereIsAlreadyAReturn [
-	class compile: 'method
-  ^self toto ifTrue: [ ^ 1 ] ifFalse: [ ^ 2 ]'.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
-  ^self toto ifTrue: [ 1 ] ifFalse: [ 2 ]'
+	self assert: '^self toto ifTrue: [ ^ 1 ] ifFalse: [ ^ 2 ]' isRewrittenAs: '^self toto ifTrue: [ 1 ] ifFalse: [ 2 ]'
 ]
 
 { #category : #tests }
 ChanelExtractReturnFromAllBranchesCleanerTest >> testExtractReturnFromIfEmptyIfNotEmpty [
-	class compile: 'method
-  self toto ifEmpty: [ ^ 2 ] ifNotEmpty: [ ^ 1 ]'.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
-  ^self toto ifEmpty: [ 2 ] ifNotEmpty: [ 1 ]'
+	self assert: 'self toto ifEmpty: [ ^ 2 ] ifNotEmpty: [ ^ 1 ]' isRewrittenAs: '^self toto ifEmpty: [ 2 ] ifNotEmpty: [ 1 ]'
 ]
 
 { #category : #tests }
 ChanelExtractReturnFromAllBranchesCleanerTest >> testExtractReturnFromIfExistsIfAbsent [
-	class compile: 'method
-  self toto ifExists: [ ^ 2 ] ifAbsent: [ ^ 1 ]'.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
-  ^self toto ifExists: [ 2 ] ifAbsent: [ 1 ]'
+	self assert: 'self toto ifExists: [ ^ 2 ] ifAbsent: [ ^ 1 ]' isRewrittenAs: '^self toto ifExists: [ 2 ] ifAbsent: [ 1 ]'
 ]
 
 { #category : #tests }
 ChanelExtractReturnFromAllBranchesCleanerTest >> testExtractReturnFromIfFalseIfTrue [
-	class compile: 'method
-  self toto ifFalse: [ ^ 2 ] ifTrue: [ ^ 1 ]'.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
-  ^self toto ifFalse: [ 2 ] ifTrue: [ 1 ]'
+	self assert: 'self toto ifFalse: [ ^ 2 ] ifTrue: [ ^ 1 ]' isRewrittenAs: '^self toto ifFalse: [ 2 ] ifTrue: [ 1 ]'
 ]
 
 { #category : #tests }
 ChanelExtractReturnFromAllBranchesCleanerTest >> testExtractReturnFromIfNilIfNotNil [
-	class compile: 'method
-  self toto ifNil: [ ^ 2 ] ifNotNil: [ ^ 1 ]'.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
-  ^self toto ifNil: [ 2 ] ifNotNil: [ 1 ]'
+	self assert: 'self toto ifNil: [ ^ 2 ] ifNotNil: [ ^ 1 ]' isRewrittenAs: '^self toto ifNil: [ 2 ] ifNotNil: [ 1 ]'
 ]
 
 { #category : #tests }
 ChanelExtractReturnFromAllBranchesCleanerTest >> testExtractReturnFromIfNotEmptyIfEmpty [
-	class compile: 'method
-  self toto ifNotEmpty: [ ^ 2 ] ifEmpty: [ ^ 1 ]'.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
-  ^self toto ifNotEmpty: [ 2 ] ifEmpty: [ 1 ]'
+	self assert: 'self toto ifNotEmpty: [ ^ 2 ] ifEmpty: [ ^ 1 ]' isRewrittenAs: '^self toto ifNotEmpty: [ 2 ] ifEmpty: [ 1 ]'
 ]
 
 { #category : #tests }
 ChanelExtractReturnFromAllBranchesCleanerTest >> testExtractReturnFromIfNotNilIfNil [
-	class compile: 'method
-  self toto ifNotNil: [ ^ 2 ] ifNil: [ ^ 1 ]'.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
-  ^self toto ifNotNil: [ 2 ] ifNil: [ 1 ]'
+	self assert: 'self toto ifNotNil: [ ^ 2 ] ifNil: [ ^ 1 ]' isRewrittenAs: '^self toto ifNotNil: [ 2 ] ifNil: [ 1 ]'
 ]
 
 { #category : #tests }
 ChanelExtractReturnFromAllBranchesCleanerTest >> testExtractReturnFromIfTrueIfFalse [
-	class compile: 'method
-  self toto ifTrue: [ ^ 1 ] ifFalse: [ ^ 2 ]'.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
-  ^self toto ifTrue: [ 1 ] ifFalse: [ 2 ]'
+	self assert: 'self toto ifTrue: [ ^ 1 ] ifFalse: [ ^ 2 ]' isRewrittenAs: '^self toto ifTrue: [ 1 ] ifFalse: [ 2 ]'
 ]
 
 { #category : #tests }
 ChanelExtractReturnFromAllBranchesCleanerTest >> testExtractReturnFromIfTrueIfFalseWithOtherStatements [
-	class compile: 'method
-  self toto ifTrue: [ self foo. ^ 1 ] ifFalse: [ ^ self bar ]'.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
-  ^self toto ifTrue: [ self foo.
+	self assert: 'self toto ifTrue: [ self foo. ^ 1 ] ifFalse: [ ^ self bar ]' isRewrittenAs: '^self toto ifTrue: [ self foo.
         1 ] ifFalse: [ self bar ]'
 ]
 
 { #category : #tests }
 ChanelExtractReturnFromAllBranchesCleanerTest >> testExtractReturnIfTheLastStatementOfABlock [
-	class compile: 'method
-  self foo ifTrue: [ self toto ifTrue: [ ^ 1 ] ifFalse: [ ^ 2 ] ].
-  self bar'.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
-  self foo ifTrue: [ ^self toto ifTrue: [ 1 ] ifFalse: [ 2 ] ].
+	self
+		assert:
+			'self foo ifTrue: [ self toto ifTrue: [ ^ 1 ] ifFalse: [ ^ 2 ] ].
+  self bar'
+		isRewrittenAs:
+			'self foo ifTrue: [ ^self toto ifTrue: [ 1 ] ifFalse: [ 2 ] ].
   self bar'
 ]
 
 { #category : #tests }
 ChanelExtractReturnFromAllBranchesCleanerTest >> testExtractReturnInNestedConditions [
-	class compile: 'method
-	self toto1 ifTrue: [ self toto2 ifTrue: [ ^1 ] ifFalse: [ ^2 ] ] ifFalse: [ ^3 ]'.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
-  ^self toto1 ifTrue: [ self toto2 ifTrue: [ 1 ] ifFalse: [ 2 ] ] ifFalse: [ 3 ]'
+	self
+		assert: 'self toto1 ifTrue: [ self toto2 ifTrue: [ ^1 ] ifFalse: [ ^2 ] ] ifFalse: [ ^3 ]'
+		isRewrittenAs: '^self toto1 ifTrue: [ self toto2 ifTrue: [ 1 ] ifFalse: [ 2 ] ] ifFalse: [ 3 ]'
 ]
 
 { #category : #tests }
@@ -297,11 +141,5 @@ ChanelExtractReturnFromAllBranchesCleanerTest >> testExtractReturnInTrait [
 
 { #category : #tests }
 ChanelExtractReturnFromAllBranchesCleanerTest >> testExtractReturnOnClassSide [
-	class class compile: 'method
-  self toto ifTrue: [ ^ 1 ] ifFalse: [ ^ 2 ]'.
-
-	self runCleaner.
-	
-	self assert: (class class >> #method) sourceCode equals: 'method
-  ^self toto ifTrue: [ 1 ] ifFalse: [ 2 ]'
+	self assert: 'self toto ifTrue: [ ^ 1 ] ifFalse: [ ^ 2 ]' isRewrittenAs: '^self toto ifTrue: [ 1 ] ifFalse: [ 2 ]' in: class class
 ]

--- a/src/Chanel-Tests/ChanelMethodRewriterCleanerTest.class.st
+++ b/src/Chanel-Tests/ChanelMethodRewriterCleanerTest.class.st
@@ -12,22 +12,6 @@ ChanelMethodRewriterCleanerTest class >> isAbstract [
 	^ self = ChanelMethodRewriterCleanerTest
 ]
 
-{ #category : #helpers }
-ChanelMethodRewriterCleanerTest >> assert: original isRewrittenAs: expected [
-	class ifNil: [ self error: 'To use this method you need to setup the class variable' ].
-
-	self assert: original isRewrittenAs: expected in: class
-]
-
-{ #category : #helpers }
-ChanelMethodRewriterCleanerTest >> assert: original isRewrittenAs: expected in: aClass [
-	aClass compile: (self methodBodyFor: original).
-
-	self runCleaner.
-
-	self assert: (aClass >> self selector) sourceCode equals: (self methodBodyFor: expected)
-]
-
 { #category : #tests }
 ChanelMethodRewriterCleanerTest >> assertReplacementWasDoneIn: trait [
 	self assert: (trait >> self selector) sourceCode equals: (self methodBodyFor: self replacementPair value).
@@ -46,21 +30,6 @@ ChanelMethodRewriterCleanerTest >> deny: original isRewrittenForPharo: anInteger
 	oldMethod := class >> self selector.
 
 	self runCleanerForPharo: anInteger.
-
-	self assert: class >> self selector identicalTo: oldMethod
-]
-
-{ #category : #helpers }
-ChanelMethodRewriterCleanerTest >> denyIsRewritten: aString [
-	| oldMethod |
-	class ifNil: [ self error: 'To use this method you need to setup the class variable' ].
-
-	class compile: (self methodBodyFor: aString).
-
-	oldMethod := class >> self selector.
-	self runCleaner.
-
-	self assert: (class >> self selector) sourceCode equals: (self methodBodyFor: aString).
 
 	self assert: class >> self selector identicalTo: oldMethod
 ]

--- a/src/Chanel-Tests/ChanelRemoveUnusedNodesFromASTCleanerTest.class.st
+++ b/src/Chanel-Tests/ChanelRemoveUnusedNodesFromASTCleanerTest.class.st
@@ -15,247 +15,137 @@ ChanelRemoveUnusedNodesFromASTCleanerTest >> setUp [
 
 { #category : #tests }
 ChanelRemoveUnusedNodesFromASTCleanerTest >> testDoesNotRemoveNodesInAssignation [
-	| oldMethod |
-	class compile: 'method
-  test := 1'.
-
-	oldMethod := class >> #method.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
-  test := 1'.
-
-	self assert: (class >> #method) equals: oldMethod
+	self denyIsRewritten: 'test := 1'
 ]
 
 { #category : #tests }
 ChanelRemoveUnusedNodesFromASTCleanerTest >> testDoesNotRemoveNodesInByteArray [
-	| oldMethod |
-	class compile: 'method
-  ^#[1]'.
-
-	oldMethod := class >> #method.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
-  ^#[1]'.
-
-	self assert: (class >> #method) equals: oldMethod
+	self denyIsRewritten: '^#[1]'
 ]
 
 { #category : #tests }
 ChanelRemoveUnusedNodesFromASTCleanerTest >> testDoesNotRemoveNodesInDynamicArray [
-	| oldMethod |
-	class compile: 'method
-  ^{ 1 }'.
-
-	oldMethod := class >> #method.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
-  ^{ 1 }'.
-
-	self assert: (class >> #method) equals: oldMethod
+	self denyIsRewritten: '^{ 1 }'
 ]
 
 { #category : #tests }
 ChanelRemoveUnusedNodesFromASTCleanerTest >> testDoesNotRemoveNodesInLiteralArray [
-	| oldMethod |
-	class compile: 'method
-  ^#(1)'.
-
-	oldMethod := class >> #method.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
-  ^#(1)'.
-
-	self assert: (class >> #method) equals: oldMethod
+	self denyIsRewritten: '^#(1)'
 ]
 
 { #category : #tests }
 ChanelRemoveUnusedNodesFromASTCleanerTest >> testDoesNotRemoveNodesInPragma [
-	| oldMethod |
-	class compile: 'method
-  <test: 1>'.
-
-	oldMethod := class >> #method.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
-  <test: 1>'.
-
-	self assert: (class >> #method) equals: oldMethod
+	self denyIsRewritten: '<test: 1>'
 ]
 
 { #category : #tests }
 ChanelRemoveUnusedNodesFromASTCleanerTest >> testDoesNotRemoveNodesInReturn [
-	| oldMethod |
-	class compile: 'method
-  ^1'.
-
-	oldMethod := class >> #method.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
-  ^1'.
-
-	self assert: (class >> #method) equals: oldMethod
+	self denyIsRewritten: '^1'
 ]
 
 { #category : #tests }
 ChanelRemoveUnusedNodesFromASTCleanerTest >> testDoesNotRemoveNodesReceivingMessages [
-	| oldMethod |
-	class compile: 'method
-  1 asString'.
-
-	oldMethod := class >> #method.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
-  1 asString'.
-
-	self assert: (class >> #method) equals: oldMethod
+	self denyIsRewritten: '1 asString'
 ]
 
 { #category : #tests }
 ChanelRemoveUnusedNodesFromASTCleanerTest >> testRemove2UselessNodes [
-	class compile: 'method
-  ''test''.
+	self
+		assert:
+			'''test''.
   #test2.
-  ^1'.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
   ^1'
+		isRewrittenAs: '^1'
 ]
 
 { #category : #tests }
 ChanelRemoveUnusedNodesFromASTCleanerTest >> testRemoveUselessArgumentRead [
-	class compile: 'method: test
-  test.
-  ^test'.
-
-	self runCleaner.
-	
-	self assert: (class >> #method:) sourceCode equals: 'method: test
+	self
+		assert:
+			'test.
   ^test'
+		isRewrittenAs: '^test'
 ]
 
 { #category : #tests }
 ChanelRemoveUnusedNodesFromASTCleanerTest >> testRemoveUselessBlock [
-	class compile: 'method
-  [ ^ 2 ].
-  ^1'.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
+	self
+		assert:
+			'[ ^ 2 ].
   ^1'
+		isRewrittenAs: '^1'
 ]
 
 { #category : #tests }
 ChanelRemoveUnusedNodesFromASTCleanerTest >> testRemoveUselessBoolean [
-	class compile: 'method
-  true.
-  ^1'.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
+	self
+		assert:
+			'true.
   ^1'
+		isRewrittenAs: '^1'
 ]
 
 { #category : #tests }
 ChanelRemoveUnusedNodesFromASTCleanerTest >> testRemoveUselessByteArray [
-	class compile: 'method
-  #[1].
-  ^1'.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
+	self
+		assert:
+			'#[1].
   ^1'
+		isRewrittenAs: '^1'
 ]
 
 { #category : #tests }
 ChanelRemoveUnusedNodesFromASTCleanerTest >> testRemoveUselessDynamicArray [
-	class compile: 'method
-  { 1 . 2 }.
-  ^1'.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
+	self
+		assert:
+			'{ 1 . 2 }.
   ^1'
+		isRewrittenAs: '^1'
 ]
 
 { #category : #tests }
 ChanelRemoveUnusedNodesFromASTCleanerTest >> testRemoveUselessGlobal [
-	class compile: 'method
-  Object.
-  ^1'.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
+	self
+		assert:
+			'Object.
   ^1'
+		isRewrittenAs: '^1'
 ]
 
 { #category : #tests }
 ChanelRemoveUnusedNodesFromASTCleanerTest >> testRemoveUselessInstanceVariableRead [
-	class compile: 'method
-  test.
-  ^1'.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
+	self
+		assert:
+			'test.
   ^1'
+		isRewrittenAs: '^1'
 ]
 
 { #category : #tests }
 ChanelRemoveUnusedNodesFromASTCleanerTest >> testRemoveUselessLiteralArray [
-	class compile: 'method
-  #(1 2).
-  ^1'.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
+	self
+		assert:
+			'#(1 2).
   ^1'
+		isRewrittenAs: '^1'
 ]
 
 { #category : #tests }
 ChanelRemoveUnusedNodesFromASTCleanerTest >> testRemoveUselessNil [
-	class compile: 'method
-  nil.
-  ^1'.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
+	self
+		assert:
+			'nil.
   ^1'
+		isRewrittenAs: '^1'
 ]
 
 { #category : #tests }
 ChanelRemoveUnusedNodesFromASTCleanerTest >> testRemoveUselessNodeInAnUnselessNode [
-	class compile: 'method
-  [''test''].
-  ^1'.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
+	self
+		assert:
+			'[''test''].
   ^1'
+		isRewrittenAs: '^1'
 ]
 
 { #category : #tests }
@@ -279,100 +169,78 @@ ChanelRemoveUnusedNodesFromASTCleanerTest >> testRemoveUselessNodeInTrait [
 
 { #category : #tests }
 ChanelRemoveUnusedNodesFromASTCleanerTest >> testRemoveUselessNodeOnClassSide [
-	class class compile: 'method
-  ''test''.
-  ^1'.
-
-	self runCleaner.
-	
-	self assert: (class class >> #method) sourceCode equals: 'method
+	self
+		assert:
+			'''test''.
   ^1'
+		isRewrittenAs: '^1'
+		in: class class
 ]
 
 { #category : #tests }
 ChanelRemoveUnusedNodesFromASTCleanerTest >> testRemoveUselessNumber [
-	class compile: 'method
-  10.
-  ^1'.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
+	self
+		assert:
+			'10.
   ^1'
+		isRewrittenAs: '^1'
 ]
 
 { #category : #tests }
 ChanelRemoveUnusedNodesFromASTCleanerTest >> testRemoveUselessSelf [
-	class compile: 'method
-  self.
-  ^1'.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
+	self
+		assert:
+			'self.
   ^1'
+		isRewrittenAs: '^1'
 ]
 
 { #category : #tests }
 ChanelRemoveUnusedNodesFromASTCleanerTest >> testRemoveUselessString [
-	class compile: 'method
-  ''test''.
-  ^1'.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
+	self
+		assert:
+			'''test''.
   ^1'
+		isRewrittenAs: '^1'
 ]
 
 { #category : #tests }
 ChanelRemoveUnusedNodesFromASTCleanerTest >> testRemoveUselessSuper [
-	class compile: 'method
-  super.
-  ^1'.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
+	self
+		assert:
+			'super.
   ^1'
+		isRewrittenAs: '^1'
 ]
 
 { #category : #tests }
 ChanelRemoveUnusedNodesFromASTCleanerTest >> testRemoveUselessSymbol [
-	class compile: 'method
-  #test.
-  ^1'.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
+	self
+		assert:
+			'#test.
   ^1'
+		isRewrittenAs: '^1'
 ]
 
 { #category : #tests }
 ChanelRemoveUnusedNodesFromASTCleanerTest >> testRemoveUselessTemporaryRead [
-	class compile: 'method
-  | test |
+	self
+		assert:
+			'| test |
   test := 2.
   test.
-  ^test'.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
-  | test |
+  ^test'
+		isRewrittenAs:
+			'| test |
   test := 2.
   ^test'
 ]
 
 { #category : #tests }
 ChanelRemoveUnusedNodesFromASTCleanerTest >> testRemoveUselessThisContext [
-	class compile: 'method
-  thisContext.
-  ^1'.
-
-	self runCleaner.
-	
-	self assert: (class >> #method) sourceCode equals: 'method
+	self
+		assert:
+			'thisContext.
   ^1'
+		isRewrittenAs: '^1'
 ]

--- a/src/Chanel-Tests/ChanelUnreadTemporaryCleanerTest.class.st
+++ b/src/Chanel-Tests/ChanelUnreadTemporaryCleanerTest.class.st
@@ -15,199 +15,112 @@ ChanelUnreadTemporaryCleanerTest >> setUp [
 
 { #category : #tests }
 ChanelUnreadTemporaryCleanerTest >> testDoesNotRemoveTemporaryReadFromDeeperScope [
-	| oldMethod |
-	class
-		compile:
-			'testMethod
-  true ifTrue: [ | test |
+	self denyIsRewritten: 'true ifTrue: [ | test |
   test := self toto.
   ^test ].
-  ^#one'.
-
-	oldMethod := class >> #testMethod.
-	self runCleaner.
-
-	self
-		assert: (class >> #testMethod) sourceCode
-		equals:
-			'testMethod
-  true ifTrue: [ | test |
-  test := self toto.
-  ^test ].
-  ^#one'.
-
-	"We should not have recompiled the method if we do not clean it."
-	self assert: class >> #testMethod identicalTo: oldMethod
+  ^#one'
 ]
 
 { #category : #tests }
 ChanelUnreadTemporaryCleanerTest >> testDontRemoveTemporaryRead [
-	| oldMethod |
-	class
-		compile:
-			'testMethod
-  | test |
+	self denyIsRewritten: '| test |
   test := self toto.
-  ^test'.
-
-	oldMethod := class >> #testMethod.
-
-	self runCleaner.
-
-	self
-		assert: (class >> #testMethod) sourceCode
-		equals:
-			'testMethod
-  | test |
-  test := self toto.
-  ^test'.
-
-	"We should not have recompiled the method if we do not clean it."
-	self assert: class >> #testMethod identicalTo: oldMethod
+  ^test'
 ]
 
 { #category : #tests }
 ChanelUnreadTemporaryCleanerTest >> testRemoveTemporaries [
-	class
-		compile:
-			'testMethod
-  | test test2 |
+	self
+		assert:
+			'| test test2 |
   test := self toto.
   test2 := self toto2.
-  ^#one'.
-
-	self runCleaner.
-
-	self
-		assert: (class >> #testMethod) sourceCode
-		equals:
-			'testMethod
-  self toto.
+  ^#one'
+		isRewrittenAs:
+			'self toto.
   self toto2.
   ^#one'
 ]
 
 { #category : #tests }
 ChanelUnreadTemporaryCleanerTest >> testRemoveTemporariesOnClassSide [
-	class class
-		compile:
-			'testMethod
-  | test test2 |
+	self
+		assert:
+			'| test test2 |
   test := self toto.
   test2 := self toto2.
-  ^#one'.
-
-	self runCleaner.
-
-	self
-		assert: (class class>> #testMethod) sourceCode
-		equals:
-			'testMethod
-  self toto.
+  ^#one'
+		isRewrittenAs:
+			'self toto.
   self toto2.
   ^#one'
 ]
 
 { #category : #tests }
 ChanelUnreadTemporaryCleanerTest >> testRemoveTemporary [
-	class
-		compile:
-			'testMethod
-  | test |
-  test := self toto.
-  ^#one'.
-
-	self runCleaner.
-
 	self
-		assert: (class >> #testMethod) sourceCode
-		equals:
-			'testMethod
-  self toto.
+		assert:
+			'| test |
+  test := self toto.
+  ^#one'
+		isRewrittenAs:
+			'self toto.
   ^#one'
 ]
 
 { #category : #tests }
 ChanelUnreadTemporaryCleanerTest >> testRemoveTemporary2 [
-	class
-		compile:
-			'testMethod
-  | test |
+	self
+		assert:
+			'| test |
   test := self toto.
   test.
-  ^#one'.
-
-	self runCleaner.
-
-	self
-		assert: (class >> #testMethod) sourceCode
-		equals:
-			'testMethod
-  self toto.
+  ^#one'
+		isRewrittenAs:
+			'self toto.
   ^#one'
 ]
 
 { #category : #tests }
 ChanelUnreadTemporaryCleanerTest >> testRemoveTemporaryFromDeeperScope [
-	class
-		compile:
-			'testMethod
-  true ifTrue: [ | test |
+	self
+		assert:
+			'true ifTrue: [ | test |
   test := self toto
   ].
-  ^#one'.
-
-	self runCleaner.
-
-	self
-		assert: (class >> #testMethod) sourceCode
-		equals:
-			'testMethod
-  true ifTrue: [ self toto ].
+  ^#one'
+		isRewrittenAs:
+			'true ifTrue: [ self toto ].
   ^#one'
 ]
 
 { #category : #tests }
 ChanelUnreadTemporaryCleanerTest >> testRemoveTemporaryFromDeeperScopes [
-	class
-		compile:
-			'testMethod
-  true ifTrue: [ | test |
+	self
+		assert:
+			'true ifTrue: [ | test |
   test := self toto
   ] ifFalse: [ | test |
   test := self tata
   ].
-  ^#one'.
-
-	self runCleaner.
-
-	self
-		assert: (class >> #testMethod) sourceCode
-		equals:
-			'testMethod
-  true ifTrue: [ self toto ] ifFalse: [ self tata ].
+  ^#one'
+		isRewrittenAs:
+			'true ifTrue: [ self toto ] ifFalse: [ self tata ].
   ^#one'
 ]
 
 { #category : #tests }
 ChanelUnreadTemporaryCleanerTest >> testRemoveTemporaryFromDeeperScopesWithOneRead [
-	class
-		compile:
-			'testMethod
-  true ifTrue: [ | test |
+	self
+		assert:
+			'true ifTrue: [ | test |
   test := self toto
   ] ifFalse: [ | test |
   test := self tata.
   ^test ].
-  ^#one'.
-
-	self runCleaner.
-
-	self
-		assert: (class >> #testMethod) sourceCode
-		equals:
-			'testMethod
-  true ifTrue: [ self toto ] ifFalse: [ | test |
+  ^#one'
+		isRewrittenAs:
+			'true ifTrue: [ self toto ] ifFalse: [ | test |
         test := self tata.
         ^test ].
   ^#one'

--- a/src/Chanel/ChanelCutConditionalBranchesCleaner.class.st
+++ b/src/Chanel/ChanelCutConditionalBranchesCleaner.class.st
@@ -12,7 +12,7 @@ Class {
 
 { #category : #accessing }
 ChanelCutConditionalBranchesCleaner class >> requirements [
-	^ { ChanelExtractReturnFromAllBranchesCleaner . ChanelNilConditionalSimplifierCleaner . ChanelEmptyConditionalSimplifierCleaner }
+	^ { ChanelExtractAssignationsFromConditionals . ChanelExtractReturnFromAllBranchesCleaner . ChanelNilConditionalSimplifierCleaner . ChanelEmptyConditionalSimplifierCleaner }
 ]
 
 { #category : #cleaning }

--- a/src/Chanel/ChanelExtractAssignationsFromConditionals.class.st
+++ b/src/Chanel/ChanelExtractAssignationsFromConditionals.class.st
@@ -2,22 +2,22 @@
 Description
 --------------------
 
-I am a cleaner trying to extract returns from conditions.
+I am a cleaner trying to extract assignations from conditions.
 "
 Class {
-	#name : #ChanelExtractReturnFromAllBranchesCleaner,
+	#name : #ChanelExtractAssignationsFromConditionals,
 	#superclass : #ChanelAbstractCleaner,
 	#category : #Chanel
 }
 
 { #category : #cleaning }
-ChanelExtractReturnFromAllBranchesCleaner >> clean [
+ChanelExtractAssignationsFromConditionals >> clean [
   (self cleanASTs: (self configuration localMethods collect: #ast)) do: #install
 ]
 
 { #category : #cleaning }
-ChanelExtractReturnFromAllBranchesCleaner >> cleanASTs: aCollectionOfMethods [
-	"In the end we run again the cleaning on ASTs because we can have case of nested conditionals each of the having returns in their branches."
+ChanelExtractAssignationsFromConditionals >> cleanASTs: aCollectionOfMethods [
+	"In the end we run again the cleaning on ASTs because we can have case of nested conditionals each of the having assignations in their branches."
 
 	^ (aCollectionOfMethods iterator
 		| #allChildren flatCollectIt
@@ -26,9 +26,9 @@ ChanelExtractReturnFromAllBranchesCleaner >> cleanASTs: aCollectionOfMethods [
 		| [ :node | node parent isLast: node ] selectIt
 		| #isConditionNecessarilyExecutingABranch selectIt
 		| [ :node | node arguments allSatisfy: #isBlock ] selectIt
-		| [ :node | node arguments allSatisfy: #lastStatementIsReturn ] selectIt
-		| [ :node | node arguments do: #inlineLastStatement ] doIt
-		| #wrapsInReturn doIt
+		| [ :node | node arguments allSatisfy: #lastStatementIsAssignment ] selectIt
+		| [ :node | (node arguments collect: #lastAssignmentVariable as: Set) size = 1  ] selectIt
+		| #inlineAssignationFromArguments doIt
 		| #methodNode collectIt
 		> Set) ifNotEmpty: [ :updatedASTs | self cleanASTs: updatedASTs. updatedASTs ]
 ]

--- a/src/Chanel/ChanelExtractAssignationsFromConditionals.class.st
+++ b/src/Chanel/ChanelExtractAssignationsFromConditionals.class.st
@@ -23,7 +23,6 @@ ChanelExtractAssignationsFromConditionals >> cleanASTs: aCollectionOfMethods [
 		| #allChildren flatCollectIt
 		| #isMessage selectIt
 		| #isCascaded rejectIt
-		| [ :node | node parent isLast: node ] selectIt
 		| #isConditionNecessarilyExecutingABranch selectIt
 		| [ :node | node arguments allSatisfy: #isBlock ] selectIt
 		| [ :node | node arguments allSatisfy: #lastStatementIsAssignment ] selectIt

--- a/src/Chanel/RBAssignmentNode.extension.st
+++ b/src/Chanel/RBAssignmentNode.extension.st
@@ -6,6 +6,11 @@ RBAssignmentNode >> canHaveUselessChildren [
 ]
 
 { #category : #'*Chanel' }
+RBAssignmentNode >> inline [
+	self replaceWith: self value
+]
+
+{ #category : #'*Chanel' }
 RBAssignmentNode >> removeAssignations [
 	"In case the assignation is in an assignation, we want to remove the parent aswel."
 

--- a/src/Chanel/RBBlockNode.extension.st
+++ b/src/Chanel/RBBlockNode.extension.st
@@ -1,8 +1,20 @@
 Extension { #name : #RBBlockNode }
 
 { #category : #'*Chanel' }
-RBBlockNode >> inlineLastReturn [
+RBBlockNode >> inlineLastStatement [
 	self statements last inline
+]
+
+{ #category : #'*Chanel' }
+RBBlockNode >> lastAssignmentVariable [
+	"We know that the last statement is an assignment. We want to return its value."
+
+	^ self statements last variable
+]
+
+{ #category : #'*Chanel' }
+RBBlockNode >> lastStatementIsAssignment [
+	^ self statements last isAssignment
 ]
 
 { #category : #'*Chanel' }

--- a/src/Chanel/RBMessageNode.extension.st
+++ b/src/Chanel/RBMessageNode.extension.st
@@ -6,7 +6,17 @@ RBMessageNode >> canHaveUselessChildren [
 ]
 
 { #category : #'*Chanel' }
+RBMessageNode >> inlineAssignationFromArguments [
+	| variable |
+	variable := self arguments anyOne lastAssignmentVariable.
+	self arguments do: #inlineLastStatement.
+	self replaceWith: (RBAssignmentNode variable: variable value: self copy)
+]
+
+{ #category : #'*Chanel' }
 RBMessageNode >> isConditionNecessarilyExecutingABranch [
+	"I contains a collection of conditionals that will always end up executing one of their branch. So we know that at least one of the argument will be executed."
+
 	^ #(#ifTrue:ifFalse: #ifFalse:ifTrue: #ifNil:ifNotNil: #ifNotNil:ifNil: #ifEmpty:ifNotEmpty: #ifNotEmpty:ifEmpty: #ifExists:ifAbsent:) includes: self selector
 ]
 

--- a/src/Chanel/RBMessageNode.extension.st
+++ b/src/Chanel/RBMessageNode.extension.st
@@ -10,6 +10,9 @@ RBMessageNode >> inlineAssignationFromArguments [
 	| variable |
 	variable := self arguments anyOne lastAssignmentVariable.
 	self arguments do: #inlineLastStatement.
+
+	"If my parent is an assignment with the same name, then it's useless to wrap me in another assigment."
+	(self parent isAssignment and: [ self parent variable = variable ]) ifTrue: [ ^ self ].
 	self replaceWith: (RBAssignmentNode variable: variable value: self copy)
 ]
 

--- a/src/Chanel/RBTemporaryNode.extension.st
+++ b/src/Chanel/RBTemporaryNode.extension.st
@@ -23,7 +23,7 @@ RBTemporaryNode >> inlineAssignment [
 	"Replace the assignment in which I am by its value without the assignation to the temporary."
 
 	self parent isAssignment
-		ifTrue: [ self parent replaceWith: self parent value ]
+		ifTrue: [ self parent inline ]
 		ifFalse: [ "This might happen for dead temporaries. See testRemoveTemporary2." self removeFromTree ]
 ]
 


### PR DESCRIPTION
Add cleaner to extract assignment from conditionals. Also clean tests.Fixes #92